### PR TITLE
Add an environmental variable that points to the current DataONE CN

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -38,7 +38,6 @@ services:
       - ./girder/girder.local.cfg:/girder/girder/conf/girder.local.cfg
     environment:
       - DOMAIN=vcap.me
-      - DATAONE_CN=https://cn.dataone.org/cn
     deploy:
       replicas: 1
       labels:
@@ -65,6 +64,7 @@ services:
     environment:
       - GIRDER_API_URL=http://girder.vcap.me
       - AUTH_PROVIDER=GitHub
+      - DATAONE_URL=https://cn.dataone.org
     deploy:
       replicas: 1
       labels:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -38,6 +38,7 @@ services:
       - ./girder/girder.local.cfg:/girder/girder/conf/girder.local.cfg
     environment:
       - DOMAIN=vcap.me
+      - DATAONE_CN=https://cn.dataone.org/cn
     deploy:
       replicas: 1
       labels:


### PR DESCRIPTION
Add an environmental variable that points to the current DataONE CN (only varies between production, test, dev, etc).

This is needed during publishing (https://github.com/whole-tale/gwvolman/pull/37/files#diff-b6519d6e1544725c4c5ac2f56795e1eaR47). 