### PR TITLE
Add a restart_girder Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: clean dirs dev images gwvolman_src wholetale_src dms_src home_src dashboard_src sources \
-	rebuild_dashboard restart_worker
+	rebuild_dashboard restart_worker restart_girder
 
 SUBDIRS = ps homes src
 TAG = latest
@@ -52,7 +52,8 @@ dev: services
 	docker exec -ti $$(docker ps --filter=name=wt_girder -q) girder-install web --dev --plugins=oauth,gravatar,jobs,worker,wt_data_manager,wholetale,wt_home_dir
 	./setup_girder.py
 
-restart_girder:
+restart_girder: dev
+	which jq || echo "Please install jq to execute the 'restart_girder' make target" && exit 1
 	docker exec -ti $$(docker ps --filter=name=wt_girder -q) \
 		curl -XPUT -s 'http://localhost:8080/api/v1/system/restart' \
 			--header 'Content-Type: application/json' \

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,17 @@ dev: services
 	docker exec -ti $$(docker ps --filter=name=wt_girder -q) girder-install web --dev --plugins=oauth,gravatar,jobs,worker,wt_data_manager,wholetale,wt_home_dir
 	./setup_girder.py
 
+restart_girder:
+	docker exec -ti $$(docker ps --filter=name=wt_girder -q) \
+		curl -XPUT -s 'http://localhost:8080/api/v1/system/restart' \
+			--header 'Content-Type: application/json' \
+			--header 'Accept: application/json' \
+			--header 'Content-Length: 0' \
+			--header "Girder-Token: $$(docker exec -ti $$(docker ps --filter=name=wt_girder -q) \
+				curl 'http://localhost:8080/api/v1/user/authentication' \
+				--basic --user admin:arglebargle123 \
+					| jq -r .authToken.token)"
+	
 rebuild_dashboard: src/dashboard
 	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app risingstack/alpine:3.7-v8.10.0-4.8.0 npm install
 	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app risingstack/alpine:3.7-v8.10.0-4.8.0 ./node_modules/.bin/ember build --environment=production


### PR DESCRIPTION
# Problem
When developing for Girder, I sometimes accidentally save a typo. Girder, in a move that is typically super helpful, attempts to recompile the code. The compilation fails because of the typo, which leaves Girder up but the plugin is unloaded due to an error state. Since the plugin is not loaded, Girder is no longer watching its source code for changes as it usually does, so further attempts to fix the typo don't yield an automatic compile. At this point, the only way to correct the issue is to trigger a restart of Girder. 

# Approach
While it is currently possible to trigger a restart from Girder's SwaggerUI, it is disruptive to need to switch tabs or log in as a particular user and go execute a particular endpoint. For convenience, I have added a `restart_girder` target to the Makefile to perform this restart for you.

0. `dev` is listed as a dependency - we can't restart Girder if it was never set up
    * Aside: Should this be `services` instead?
1. First, we check that `jq` is installed
2. Then, we exec into the Girder container and curl `localhost:8080/api/v1/user/authentication` to login as the admin user (NOTE: credentials are now hard-coded in Makefile)
  * This step returns a `GIRDER_TOKEN`
3. Using the `GIRDER_TOKEN` from the previous step, curl `localhost:8080/api/v1/system/restart` with the token as a header to trigger a restart

# How to Test
1. Follow the current instructions in the README
2. Wait for everything to come up successfully
3. Check out this branch from SCM
4. `make restart_girder`
    * If you do not have `jq` installed, you should be prompted to install it
5. Ensure that `jq` is installed and re-run `make restart_girder`
    * Now that `jq` is installed, you should see the usual response from Girder including a timestamp of when the system responded with a reboot