### PR TITLE
Add a Flag to Tell if Dashboard is Dev

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -80,6 +80,7 @@ services:
       - GIRDER_API_URL=https://girder.local.wholetale.org
       - AUTH_PROVIDER=Globus
       - DATAONE_URL=https://cn-stage-2.test.dataone.org
+      - DASHBOARD_DEV=true
     volumes:
       - ./src/dashboard/dist:/srv/dashboard
     deploy:


### PR DESCRIPTION
This flag is used in data registration (there's a checkbox that appears when ENV.dev==true). This wasn't getting set so there was no way to register data from the dataone development server (aside from adding another environmental variable for the dataone dev member node).