### PR TITLE
Pin redis image 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ src/dashboard:
 	git clone https://github.com/whole-tale/dashboard src/dashboard
 	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app risingstack/alpine:3.7-v8.10.0-4.8.0 sh -c "$$(cat dashboard_local/initial_build.sh)"
 
-src/globus_handler_src:
+src/globus_handler:
 	git clone https://github.com/whole-tale/globus_handler src/globus_handler
 
 sources: src/gwvolman src/wholetale src/wt_data_manager src/wt_home_dir src/dashboard src/globus_handler

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -62,7 +62,7 @@ services:
         - "traefik.frontend.passHostHeader=true"
         - "traefik.frontend.entryPoints=https"
 
-  redis:
+  redis:4-stretch
     image: redis
     networks:
       - celery


### PR DESCRIPTION
As reported in https://github.com/whole-tale/gwvolman/issues/56#issuecomment-471184829, an update to redis causes problems with gwvolman.  This PR pins the redis image version to one that works.  I also corrected a problem with the `globus_handler` source directory name that was failing for me.

Test:
* `make dev` should succeed and `gwvolman` start without the redis error