### PR TITLE
Add watch_dashboard, change dashboard build base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: clean dirs dev images gwvolman_src wholetale_src dms_src home_src dashboard_src sources \
-	rebuild_dashboard restart_worker restart_girder globus_handler_src
+	rebuild_dashboard watch_dashboard restart_worker restart_girder globus_handler_src
 
 SUBDIRS = ps homes src
 TAG = latest
@@ -9,7 +9,7 @@ images:
 	docker pull mongo:3.2
 	docker pull redis:latest
 	docker pull registry:2.6
-	docker pull risingstack/alpine:3.7-v8.10.0-4.8.0
+	docker pull node:carbon-slim
 	docker pull wholetale/girder:$(TAG)
 	docker pull wholetale/gwvolman:$(TAG)
 
@@ -27,7 +27,7 @@ src/wt_home_dir:
 
 src/dashboard:
 	git clone https://github.com/whole-tale/dashboard src/dashboard
-	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app risingstack/alpine:3.7-v8.10.0-4.8.0 sh -c "$$(cat dashboard_local/initial_build.sh)"
+	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app -w /usr/src/node-app node:carbon-slim sh -c "$$(cat dashboard_local/initial_build.sh)"
 
 src/globus_handler:
 	git clone https://github.com/whole-tale/globus_handler src/globus_handler
@@ -73,8 +73,14 @@ rebuild_dashboard: src/dashboard
 		-e "s|dashboardHOST|https://dashboard.local.wholetale.org|g" \
 		-e "s|dataOneHOST|https://cn-stage-2.test.dataone.org|g" \
 		-e "s|authPROVIDER|Globus|g" -i src/dashboard/config/environment.js
-	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app risingstack/alpine:3.7-v8.10.0-4.8.0 npm install
-	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app risingstack/alpine:3.7-v8.10.0-4.8.0 ./node_modules/.bin/ember build --environment=production
+	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app -w /usr/src/node-app node:carbon-slim sh -c 'NODE_ENV=development npm install && ./node_modules/.bin/ember build --environment=production'
+
+watch_dashboard: src/dashboard
+	sed -e "s|apiHOST|https://girder.local.wholetale.org|g" \
+                -e "s|dashboardHOST|https://dashboard.local.wholetale.org|g" \
+                -e "s|dataOneHOST|https://cn-stage-2.test.dataone.org|g" \
+                -e "s|authPROVIDER|Globus|g" -i src/dashboard/config/environment.js
+	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app -w /usr/src/node-app node:carbon-slim sh -c 'NODE_ENV=development npm install && ./node_modules/.bin/ember serve --environment=production'
 
 restart_worker:
 	./stop_worker.sh && ./run_worker.sh

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ dev: services
 	docker exec -ti $$(docker ps --filter=name=wt_girder -q) girder-install web --dev --plugins=oauth,gravatar,jobs,worker,wt_data_manager,wholetale,wt_home_dir,globus_handler
 	./setup_girder.py
 
-restart_girder: dev
-	which jq || echo "Please install jq to execute the 'restart_girder' make target" && exit 1
+restart_girder: 
+	which jq || (echo "Please install jq to execute the 'restart_girder' make target" && exit 1)
 	docker exec -ti $$(docker ps --filter=name=wt_girder -q) \
 		curl -XPUT -s 'http://localhost:8080/api/v1/system/restart' \
 			--header 'Content-Type: application/json' \

--- a/pull-upstream.sh
+++ b/pull-upstream.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# By default, this script will pull from upstream master in all watched subdirectories.
+# The user may optionally pass a comma-separated subset of watched subdirectories from 
+# which to pull.
+#
+# Usage: ./pull-upstream.sh [subdirectory1,subdirectory2,subdirectory3,...]
+# 
+
+# DEBUG="echo -e"
+
+# Error out if not in deploy-dev root
+root_dir=$(pwd)
+if [[ "$root_dir" != *deploy-dev ]]; then
+	echo "ERROR: This script should be run from the deploy-dev repository root."
+	exit 1
+fi
+
+# Default parameter to all subdirs
+if [ "$1" == "" ]; then
+	subdirs="dashboard,wholetale,gwvolman,wt_data_manager,wt_home_dir,globus_handler"
+else
+	subdirs="$1"
+fi
+
+# Loop over supplied subdirectories and pull from upstream
+for subdir in $(echo "$subdirs" | sed "s/,/ /g")
+do
+	($DEBUG cd $root_dir/src/$subdir && $DEBUG git pull origin master) || exit 1
+done


### PR DESCRIPTION
### Problem
There are inconsistencies between host and dashboard build environment. This manifests in some strange behaviors with the `node_modules` folder. For example, I would frequently encounter errors during `npm install` similar to the following:
```
npm ERR! enoent ENOENT: no such file or directory, rename 'node_modules/npm/node_modules/dezalgo' -> 'node_modules/npm/node_modules/.dezalgo.DELETE'
npm ERR! enoent This is related to npm not being able to find a file.
```

Deleting `node_modules` and re-running would sometimes fix the issue, but other times not

### Approach
* Changed dashboard build base image from `risingstack/alpine:3.7-v8.10.0-4.8.0` to `node:carbon-slim`
* Added a `watch_dashboard` make target for continuously rebuilding the dashboard as the code changes
* Added a `pull-upstream.sh` script that will synchronize all (or optionally a subset) of the supported `deploy-dev` source directories

### How to Test
1. Follow the setup instructions in the `dev` branch of this repo's README.md
2. Instead of `rebuild_dashboard`, run `watch_dashboard`
    * You should see the usual `npm install` and `ember build` steps begin and complete
    * After the build is complete, the process should stay active (e.g. it should not terminate)
3. Touch a file in the dashboard source: e.g. `touch src/dashboard/config/environment.js` and check the watcher output
    * You should see `src/dashboard/config/environment.js changed` in the watcher output - this means a rebuild has been triggered
4. Wait a minute or so for the watcher's build to complete
    * You should eventually see metrics printed about the incremental rebuild
    