### PR TITLE
Add a dev flag to the dashboard config section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ rebuild_dashboard: src/dashboard
 	sed -e "s|apiHOST|https://girder.local.wholetale.org|g" \
 		-e "s|dashboardHOST|https://dashboard.local.wholetale.org|g" \
 		-e "s|dataOneHOST|https://cn-stage-2.test.dataone.org|g" \
+		-e "s|dashboardDev|true|g" \
 		-e "s|authPROVIDER|Globus|g" -i src/dashboard/config/environment.js
 	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app -w /usr/src/node-app node:carbon-slim sh -c 'NODE_ENV=development npm install && ./node_modules/.bin/ember build --environment=production'
 
@@ -79,6 +80,7 @@ watch_dashboard: src/dashboard
 	sed -e "s|apiHOST|https://girder.local.wholetale.org|g" \
                 -e "s|dashboardHOST|https://dashboard.local.wholetale.org|g" \
                 -e "s|dataOneHOST|https://cn-stage-2.test.dataone.org|g" \
+		-e "s|dashboardDev|true|g" \
                 -e "s|authPROVIDER|Globus|g" -i src/dashboard/config/environment.js
 	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app -w /usr/src/node-app node:carbon-slim sh -c 'NODE_ENV=development npm install && ./node_modules/.bin/ember serve --environment=production'
 


### PR DESCRIPTION
This PR allows developers to set the `dashoardDev` flag in the dashboard config.

To Test:
1. Check this branch out
2. Checkout [dataone_login_refacor](https://github.com/whole-tale/dashboard/pull/474)
3. Set the flag to true
4. Rebuild the dashboard
5. vi the dashboard's `environment.js` file and make sure the value is correct
6. Checkout `environment.js`
7. Change the flag
8. Run `rebuild_dashboard`
9. Confirm the flag in `environment.js` is correct

@Xarthisius, should I make an additional PR to [terraform_deployment variables](https://github.com/whole-tale/terraform_deployment/blob/master/variables.tf) so that this properly gets set to `false` on production?