### PR TITLE
Added "next.local.wholetale.org" to access the Angular dashboard

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -93,6 +93,25 @@ services:
         - "traefik.frontend.passHostHeader=true"
         - "traefik.frontend.entryPoints=https"
 
+  dashboard_next:
+    image: bodom0015/ng-dashboard:wt
+    networks:
+      - traefik-net
+    environment:
+      - GIRDER_API_URL=https://girder.local.wholetale.org
+      - AUTH_PROVIDER=Globus
+      - DATAONE_URL=https://cn-stage-2.test.dataone.org
+      - DASHBOARD_DEV=true
+    deploy:
+      replicas: 1
+      labels:
+        - "traefik.port=80"
+        - "traefik.frontend.rule=Host:next.local.wholetale.org"
+        - "traefik.enable=true"
+        - "traefik.docker.network=wt_traefik-net"
+        - "traefik.frontend.passHostHeader=true"
+        - "traefik.frontend.entryPoints=https"
+
   registry:
     image: registry:2.6
     networks:

--- a/setup_girder.py
+++ b/setup_girder.py
@@ -96,7 +96,7 @@ print("Setting up Plugin")
 settings = [
     {
         "key": "core.cors.allow_origin",
-        "value": "https://dashboard.local.wholetale.org,https://next.local.wholetale.org",
+        "value": "https://dashboard.local.wholetale.org,http://localhost:4200,https://next.local.wholetale.org",
     },
     {
         "key": "core.cors.allow_headers",

--- a/setup_girder.py
+++ b/setup_girder.py
@@ -96,7 +96,7 @@ print("Setting up Plugin")
 settings = [
     {
         "key": "core.cors.allow_origin",
-        "value": "https://dashboard.local.wholetale.org,http://localhost:4200",
+        "value": "https://dashboard.local.wholetale.org,https://next.local.wholetale.org",
     },
     {
         "key": "core.cors.allow_headers",


### PR DESCRIPTION
## Problem
We don't have an easy way to run the new Angular dashboard while maintaining existing development patterns on the EmberJS (legacy) dashboard.

## Approach
Added `https://next.local.wholetale.org` that can run the Angular dashboard.

NOTE: the `environment` section is currently unused and may go away in the near future, but these values were preserved from the legacy dashboard.

## How to Test
NOTE: For existing deployments, there is one manual configuration step due to `setup_girder.py` short-circuiting if the admin user already exists.

### With a new deployment
1. Execute `make clean` (and perform any manual cleanup necessary)
2. Checkout and run this branch locally
3. Execute `make dev` and wait for completion
    * You should see `Creating service wt_dashboard_next` in the output
4. Navigate to https://next.local.wholetale.org
    * You should be greeted with a familiarly-styled WholeTale login page
5. Click "Access WholeTale" to login and access the rest of the Dashboard

### With an existing deployment
1. Checkout and run this branch locally
2. Execute `make dev`
    * You should see `Creating service wt_dashboard_next` in the output
3. Navigate to https://girder.local.wholetale.org, log in as the admin, locate Admin console > Server configuration, scroll all the way down, and expand "Advanced Configuration"
4. Under CORS, make sure your "CORS Allowed Origins" includes `https://next.local.wholetale.org` as one of the values and click Save
    * NOTE: this manual step is only necessary with a deployment that existed previously
5. Navigate to https://next.local.wholetale.org
    * You should be greeted with a familiarly-styled WholeTale login page
6. Click "Access WholeTale" to login and access the rest of the Dashboard

## NOTES
Things that should work:
* General navigation - navbar, tabs, etc
* Login via Globus
* Create Tale
  * Analyze in WT (`asTale` is currently hard-coded to false)
* Run/Stop/Delete Tale
  * Copy on Launch (does not automatically navigate you to the new Tale copy)
* Run View
  * Edit / Save Metadata (currently no notification on success)
  * Browse / Upload Files (although uploading to the "Home" folder may not yet work)
    * Upload to / Browse Home Folder
    * Register new / Browse External Data
    * Upload to / Browse Tale Workspace

Things that probably won't work:
* Page titles are likely nonsense
* Run > Interact tab - iframe is currently hitting a `content-security-policy` error
* Search filter on the "Tales Catalog" view currently does nothing
* "Data Catalog" and "Compute Environments" still use placeholder data from the mockups, as these new views are out-of-scope for the rewrite
* There is no `publish-modal` yet - this is intentional, as we are about to rewrite it
* There is no "Configure Additional Accounts" view yet - this is coming soon
* Forms likely do not yet have any validation
* "Create and Launch" has been removed
* Automatic navigation is not yet in place for "Run Tale" / "Copy on Launch" cases

About the dashboard source code:
* See https://github.com/bodom0015/wt-ng-dash
* Needs a new README / better documentation
* Git history needs to be truncated and either a) detached from fork or b) pushed over current EmberJS code repo
* Outstanding issues need to be filed (currently in checklist form in raw notes)