### PR TITLE
Added "next.local.wholetale.org" development patterns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: clean dirs dev images gwvolman_src wholetale_src dms_src home_src dashboard_src sources \
-	rebuild_dashboard watch_dashboard watch_dashboard_dev restart_worker restart_girder globus_handler_src
+	rebuild_dashboard rebuild_dashboard_next watch_dashboard watch_dashboard_dev watch_dashboard_next \
+	restart_worker restart_girder globus_handler_src
 
 SUBDIRS = ps homes src
 TAG = latest
@@ -102,6 +103,9 @@ watch_dashboard_dev: src/dashboard
                 -e "s|dataOneHOST|https://cn-stage-2.test.dataone.org|g" \
                 -e "s|authPROVIDER|Globus|g" -i src/dashboard/config/environment.js
 	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app -w /usr/src/node-app node:carbon-slim sh -c 'NODE_ENV=development npm install && ./node_modules/.bin/ember serve'
+
+rebuild_dashboard_next:
+	docker run --rm --user=1000:1000 -ti -v $${PWD}/src/wt_ng_dashboard:/srv/app -w /srv/app bodom0015/ng '${YARN} install --network-timeout=360000 && ${NG} build --prod --deleteOutputPath=false --progress'
 
 watch_dashboard_next:
 	docker run --rm --user=1000:1000 -ti -v $${PWD}/src/wt_ng_dashboard:/srv/app -w /srv/app bodom0015/ng '${YARN} install --network-timeout=360000 && ${NG} build --prod --watch --poll 15000 --deleteOutputPath=false --progress'

--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,10 @@ watch_dashboard_dev: src/dashboard
 	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app -w /usr/src/node-app node:carbon-slim sh -c 'NODE_ENV=development npm install && ./node_modules/.bin/ember serve'
 
 rebuild_dashboard_next:
-	docker run --rm --user=1000:1000 -ti -v $${PWD}/src/wt_ng_dashboard:/srv/app -w /srv/app bodom0015/ng '${YARN} install --network-timeout=360000 && ${NG} build --prod --deleteOutputPath=false --progress'
+	docker run --rm --user=$${UID}:$${GID} -ti -v $${PWD}/src/wt_ng_dashboard:/srv/app -w /srv/app bodom0015/ng '${YARN} install --network-timeout=360000 && ${NG} build --prod --deleteOutputPath=false --progress'
 
 watch_dashboard_next:
-	docker run --rm --user=1000:1000 -ti -v $${PWD}/src/wt_ng_dashboard:/srv/app -w /srv/app bodom0015/ng '${YARN} install --network-timeout=360000 && ${NG} build --prod --watch --poll 15000 --deleteOutputPath=false --progress'
+	docker run --rm --user=$${UID}:$${GID} -ti -v $${PWD}/src/wt_ng_dashboard:/srv/app -w /srv/app bodom0015/ng '${YARN} install --network-timeout=360000 && ${NG} build --prod --watch --poll 15000 --deleteOutputPath=false --progress'
 
 restart_worker:
 	docker exec --user=root -ti $$(docker ps --filter=name=wt_girder -q) pip install -e /gwvolman

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ src/globus_handler:
 	git clone https://github.com/whole-tale/globus_handler src/globus_handler
 
 src/dashboard_next:
-	git clone https://github.com/bodom0015/wt-ng-dash src/wt_ng_dashboard
+	git clone https://github.com/whole-tale/ngx-dashboard src/wt_ng_dashboard
 
 sources: src/gwvolman src/wholetale src/wt_data_manager src/wt_home_dir src/dashboard src/globus_handler src/girderfs src/dashboard_next
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 
 SUBDIRS = ps homes src
 TAG = latest
+MEM_LIMIT = 2048
+NODE = node --max_old_space_size=${MEM_LIMIT}
+NG = ${NODE} ./node_modules/@angular/cli/bin/ng
+YARN = ${NODE} /usr/local/bin/yarn
 
 images:
 	docker pull traefik:alpine
@@ -99,8 +103,8 @@ watch_dashboard_dev: src/dashboard
                 -e "s|authPROVIDER|Globus|g" -i src/dashboard/config/environment.js
 	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app -w /usr/src/node-app node:carbon-slim sh -c 'NODE_ENV=development npm install && ./node_modules/.bin/ember serve'
 
-watch_dashboard_next: 
-	docker run --rm -tid -v $${PWD}/src/wt_ng_dashboard:/srv/app -w /srv/app bodom0015/ng
+watch_dashboard_next:
+	docker run --rm --user=1000:1000 -ti -v $${PWD}/src/wt_ng_dashboard:/srv/app -w /srv/app bodom0015/ng '${YARN} install --network-timeout=360000 && ${NG} build --prod --watch --poll 15000 --deleteOutputPath=false --progress'
 
 restart_worker:
 	docker exec --user=root -ti $$(docker ps --filter=name=wt_girder -q) pip install -e /gwvolman

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -111,6 +111,9 @@ services:
         - "traefik.docker.network=wt_traefik-net"
         - "traefik.frontend.passHostHeader=true"
         - "traefik.frontend.entryPoints=https"
+# Uncomment after running "ng build --prod --watch" to enable local development
+#    volumes:
+#      - ./src/wt_ng_dashboard/dist/browser/:/usr/share/nginx/html/
 
   registry:
     image: registry:2.6


### PR DESCRIPTION
**Please review and merge https://github.com/whole-tale/deploy-dev/pull/28 before looking at this PR.**

## Problem
We can now deploy the new Angular rewrite of the WT dashboard alongside Girder, but we do not have an easy way to develop against or make edits to the deployed code.

## Approach
Similar to our processes for building Ember, I added `rebuild_dashboard_next` and `watch_dashboard_next` directives to the `Makefile`.

I also included `watch_dashboard_dev`, as this is helpful for quickly developing the legacy EmberJS dashboard and builds much faster compared to the production build.

NOTE: `--deleteOutputPath=false` is needed on `ng build` because by default the `dist/` folder is deleted when rebuilding - this messes up the NGINX Docker container and causes mount failures. We avoid this by telling Angular to preserve this directory, thus preserving the Docker mount.

NOTE 2: for `watch_dashboard_next`, using `--poll 15000` is not ideal, but `--watch` to build when files change was not behaving as expected when running within Docker. `ng serve` provides auto-refresh and many other nice features, but serves entirely from memory and does not produce a `dist/` folder - this does not fit our desired pattern for mounting/serving the built code from NGINX.

## How to Test
Prerequisites:
1. Checkout and run this branch locally
2. Deploy WT stack using `make clean && make dev`
    * You should have a full WT stack running, including a running `bodom0015/ng-dashboard:wt` container
3. Verify that you can access https://next.local.wholetale.org
    * You should be directed to the new Angular dashboard

### One-Time Rebuild (Prod)
1. Make an edit to the UI (for example, modify https://github.com/bodom0015/wt-ng-dash/blob/master/src/app/%2Btale-catalog/tale-catalog/tale-catalog.component.html#L9 from `Public Tales` to `Public Tales, see?`
2. Run `make rebuild_dashboard_next`
    * `yarn` should attempt to update dependencies
    * An `ng build` process should start
3. Wait for the build to complete
4. Manually refresh https://next.local.wholetale.org
    * You should NOT receive a 500 error (this can happen when Docker loses track of the mounted path)
    * You should NOT receive a 403 error (this can happen when NGINX is serving a path with improper permissions)
    * You should see that your changes are reflected in the refreshed view

### Polling Files for Changes (Dev)
1. Run `make watch_dashboard_next`
    * `yarn` should attempt to update dependencies
    * An `ng build` process should start
2. Wait for the build to complete
3. Make an edit to the UI source code and save the file (for example, modify https://github.com/bodom0015/wt-ng-dash/blob/master/src/app/%2Btale-catalog/tale-catalog/tale-catalog.component.html#L9 from `Public Tales, see?` to `Public Tales - now I see`)
4. Wait for a new build to start (this can take ~15 seconds, per the `--poll` argument passed to the command)
    * An `ng build` process should start
5. Wait for the build to complete
6. Refresh https://next.local.wholetale.org
    * You should NOT receive a 500 error (this can happen when Docker loses track of the mounted path)
    * You should NOT receive a 403 error (this can happen when NGINX is serving a path with improper permissions)
    * You should see that your changes are reflected in the refreshed view