### PR TITLE
Change dashboard -> dashboard_old, dashboard_next -> dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: clean dirs dev images gwvolman_src wholetale_src dms_src home_src dashboard_src sources \
-	rebuild_dashboard rebuild_dashboard_next watch_dashboard watch_dashboard_dev watch_dashboard_next \
+	rebuild_dashboard_old rebuild_dashboard watch_dashboard_old watch_dashboard_old_dev watch_dashboard \
 	restart_worker restart_girder globus_handler_src
 
 SUBDIRS = ps homes src
@@ -18,6 +18,7 @@ images:
 	docker pull wholetale/girder:$(TAG)
 	docker pull wholetale/gwvolman:$(TAG)
 	docker pull wholetale/repo2docker_wholetale:$(TAG)
+	docker pull wholetale/ngx-dashboard:$(TAG)
 
 src/girderfs:
 	git clone https://github.com/whole-tale/girderfs src/girderfs
@@ -34,7 +35,7 @@ src/wt_data_manager:
 src/wt_home_dir:
 	git clone https://github.com/whole-tale/wt_home_dirs src/wt_home_dir
 
-src/dashboard:
+src/dashboard_old:
 	git clone https://github.com/whole-tale/dashboard src/dashboard
 	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app -w /usr/src/node-app node:carbon-slim sh -c "$$(cat dashboard_local/initial_build.sh)"
 
@@ -82,7 +83,7 @@ restart_girder:
                                         | jq -r .authToken.token)"
 
 	
-rebuild_dashboard: src/dashboard
+rebuild_dashboard_old: src/dashboard
 	sed -e "s|apiHOST|https://girder.local.wholetale.org|g" \
 		-e "s|dashboardHOST|https://dashboard.local.wholetale.org|g" \
 		-e "s|dataOneHOST|https://cn-stage-2.test.dataone.org|g" \
@@ -90,7 +91,7 @@ rebuild_dashboard: src/dashboard
 		-e "s|authPROVIDER|Globus|g" -i src/dashboard/config/environment.js
 	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app -w /usr/src/node-app node:carbon-slim sh -c 'NODE_ENV=development npm install && ./node_modules/.bin/ember build --environment=production'
 
-watch_dashboard: src/dashboard
+watch_dashboard_old: src/dashboard
 	sed -e "s|apiHOST|https://girder.local.wholetale.org|g" \
                 -e "s|dashboardHOST|https://dashboard.local.wholetale.org|g" \
                 -e "s|dataOneHOST|https://cn-stage-2.test.dataone.org|g" \
@@ -98,17 +99,17 @@ watch_dashboard: src/dashboard
                 -e "s|authPROVIDER|Globus|g" -i src/dashboard/config/environment.js
 	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app -w /usr/src/node-app node:carbon-slim sh -c 'NODE_ENV=development npm install && ./node_modules/.bin/ember serve --environment=production'
 
-watch_dashboard_dev: src/dashboard
+watch_dashboard_old_dev: src/dashboard
 	sed -e "s|apiHOST|https://girder.local.wholetale.org|g" \
                 -e "s|dashboardHOST|https://dashboard.local.wholetale.org|g" \
                 -e "s|dataOneHOST|https://cn-stage-2.test.dataone.org|g" \
                 -e "s|authPROVIDER|Globus|g" -i src/dashboard/config/environment.js
 	docker run --rm -ti -v $${PWD}/src/dashboard:/usr/src/node-app -w /usr/src/node-app node:carbon-slim sh -c 'NODE_ENV=development npm install && ./node_modules/.bin/ember serve'
 
-rebuild_dashboard_next:
+rebuild_dashboard:
 	docker run --rm --user=$${UID}:$${GID} -ti -v $${PWD}/src/ngx-dashboard:/srv/app -w /srv/app bodom0015/ng '${YARN} install --network-timeout=360000 && ${NG} build --prod --deleteOutputPath=false --progress'
 
-watch_dashboard_next:
+watch_dashboard:
 	docker run --rm --user=$${UID}:$${GID} -ti -v $${PWD}/src/ngx-dashboard:/srv/app -w /srv/app bodom0015/ng '${YARN} install --network-timeout=360000 && ${NG} build --prod --watch --poll 15000 --deleteOutputPath=false --progress'
 
 restart_worker:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -71,7 +71,7 @@ services:
       labels:
         - "traefik.enable=false"
 
-  dashboard:
+  dashboard_old:
     image: wholetale/dashboardproxy:latest
     # build: ./dashboard_local
     networks:
@@ -87,14 +87,14 @@ services:
       replicas: 1
       labels:
         - "traefik.port=80"
-        - "traefik.frontend.rule=Host:dashboard.local.wholetale.org"
+        - "traefik.frontend.rule=Host:legacy.local.wholetale.org"
         - "traefik.enable=true"
         - "traefik.docker.network=wt_traefik-net"
         - "traefik.frontend.passHostHeader=true"
         - "traefik.frontend.entryPoints=https"
 
-  dashboard_next:
-    image: bodom0015/ng-dashboard:wt
+  dashboard:
+    image: wholetale/ngx-dashboard:latest
     networks:
       - traefik-net
     environment:
@@ -106,7 +106,7 @@ services:
       replicas: 1
       labels:
         - "traefik.port=80"
-        - "traefik.frontend.rule=Host:next.local.wholetale.org"
+        - "traefik.frontend.rule=Host:dashboard.local.wholetale.org"
         - "traefik.enable=true"
         - "traefik.docker.network=wt_traefik-net"
         - "traefik.frontend.passHostHeader=true"

--- a/setup_girder.py
+++ b/setup_girder.py
@@ -96,7 +96,7 @@ print("Setting up Plugin")
 settings = [
     {
         "key": "core.cors.allow_origin",
-        "value": "https://dashboard.local.wholetale.org,http://localhost:4200,https://next.local.wholetale.org",
+        "value": "https://dashboard.local.wholetale.org,http://localhost:4200,https://legacy.local.wholetale.org",
     },
     {
         "key": "core.cors.allow_headers",


### PR DESCRIPTION
## Problem
Some parts of the platform (iframes, CORS, etc) rely on the hostname of the dashboard matching `dashboard(.*)?.wholetale.org`. If the hostname is incorrect, some parts of the platform do not behave accordingly.

## Approach
* Updated deployed Docker image to use `wholetale/ngx-dashboard:latest`
* Added `wholetale/ngx-dashboard:latest` to the list of images fetched by `make images`
* Updated `dashboard.local.wholetale.org` hostname to instead use `legacy.local.wholetale.org`
* Updated `next.local.wholetale.org` hostname to instead use `dashboard.local.wholetale.org`
* Updated all other references of `dashboard` to use `dashboard_old` instead
* Updated all other references of `dashboard_next`to use `dashboard` instead

NOTE: `legacy.local.wholetale.org` now hits CORS errors, and will not function as intended

## How to Test
1. Checkout and run this branch locally
2. Execute `make clean && make dev`
3. Wait for everything to come up
    * You should now be able to access the Angular WT Dashboard via https://dashboard.local.wholetale.org
    * You should now be able to access the legacy Ember WT Dashboard via https://legacy.local.wholetale.org (NOTE: `legacy.local.wholetale.org` now hits CORS errors, and will not function as intended)