### PR TITLE
Updates related to whole-tale/girder_wholetale#417

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -15,9 +15,9 @@ services:
       - ./traefik/acme:/acme
     deploy:
       replicas: 1
-    #environment:
-    #  - GODADDY_API_KEY=...
-    #  - GODADDY_API_SECRET=...
+    environment:
+      - GODADDY_API_KEY=$WT_GODADDY_API_KEY
+      - GODADDY_API_SECRET=$WT_GODADDY_API_SECRET
 
   mongo:
     image: mongo:3.2

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -111,9 +111,8 @@ services:
         - "traefik.docker.network=wt_traefik-net"
         - "traefik.frontend.passHostHeader=true"
         - "traefik.frontend.entryPoints=https"
-# Uncomment after running "ng build --prod --watch" to enable local development
-#    volumes:
-#      - ./src/ngx-dashboard/dist/browser/:/usr/share/nginx/html/
+    volumes:
+      - ./src/ngx-dashboard/dist/browser/:/usr/share/nginx/html/
 
   registry:
     image: registry:2.6

--- a/setup_girder.py
+++ b/setup_girder.py
@@ -124,7 +124,7 @@ settings = [
     {"key": "dm.globus_gc_dir", "value": "/opt/globusconnectpersonal"},
     {
         "key": "wholetale.dataverse_extra_hosts",
-        "value": ["https://dev2.dataverse.org", "https://demo.dataverse.org"],
+        "value": ["dev2.dataverse.org", "demo.dataverse.org"],
     },
 ]
 


### PR DESCRIPTION
Also includes two additional changes that I always use locally and I'm tired of applying them every time:
* Set GODADDY envs via shell env (should be noop if you don't have them)
* Mount ngx-dashboard dist so that deployment always uses local resources.