### PR TITLE
Fix rebuild_dashboard to work with NodeJS 10 base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TAG = latest
 MEM_LIMIT = 2048
 NODE = node --max_old_space_size=${MEM_LIMIT}
 NG = ${NODE} ./node_modules/@angular/cli/bin/ng
-YARN = ${NODE} /usr/local/bin/yarn
+YARN = /usr/local/bin/yarn
 
 images:
 	docker pull traefik:alpine


### PR DESCRIPTION
## Problem
`ngx-dashboard` has switched to a NodeJS 10 base image (code name: `dubnium`), which has changed the way that we install and call `yarn`. Previously, we installed `yarn` ourselves via the `npm` package. The base image now contains `yarn`, but it now appears to be a system binary.

## Approach
Switch the Makefile to call the `yarn` binary directly, instead of calling `node` to run it.

In an attempt to fight the slowness, I have attempted to set the default memory limit for NodeJS by other means. It is unclear if this alternative is actually helping the performance/speed of `yarn`.

## How to Test
1. Checkout and run this code locally
2. Rebuild the dashboard
    * You should see `yarn` install all dependencies (Warning: this may take several minutes to complete)
    * You should see `ng` build and bundle all dependency and source modules (Warning: this may *also* take several minutes to complete)
    * You should see **not** see the following error:
```
$ make rebuild_dashboard
docker run --rm --user=${UID}:${GID} -ti -v ${PWD}/src/ngx-dashboard:/srv/app -w /srv/app bodom0015/ng 'node --max_old_space_size=2048 /usr/local/bin/yarn install --network-timeout=360000 && node --max_old_space_size=2048 ./node_modules/@angular/cli/bin/ng build --prod --deleteOutputPath=false --progress'
/opt/yarn-v1.22.4/bin/yarn:2
argv0=$(echo "$0" | sed -e 's,\\,/,g')
        ^^^^

SyntaxError: missing ) after argument list
    at Module._compile (internal/modules/cjs/loader.js:723:23)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
Makefile:110: recipe for target 'rebuild_dashboard' failed
make: *** [rebuild_dashboard] Error 1

```