### PR TITLE
Port deployment to virtual_resources

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -37,20 +37,19 @@ services:
       - celery
       - mongo
     volumes:
-      - ./homes:/tmp/wt-home-dirs
-      - ./homes:/tmp/wt-tale-dirs
-      - ./ps:/tmp/ps
+      - ./volumes:/tmp/data
       - ./girder/girder.local.cfg:/girder/girder/conf/girder.local.cfg
       - ./src/wholetale:/girder/plugins/wholetale
       - ./src/wt_data_manager:/girder/plugins/wt_data_manager
       - ./src/wt_home_dir:/girder/plugins/wt_home_dir
       - ./src/globus_handler:/girder/plugins/globus_handler
+      - ./src/virtual_resources:/girder/plugins/virtual_resources
       - ./src/gwvolman:/gwvolman
     environment:
       - DOMAIN=local.wholetale.org
       - DASHBOARD_URL=https://dashboard.local.wholetale.org
       - GOSU_USER=girder:girder
-      - "GOSU_CHOWN=/tmp/wt-home-dirs /tmp/wt-tale-dirs /tmp/ps"
+      - "GOSU_CHOWN=/tmp/data"
       - DATAONE_URL=https://cn-stage-2.test.dataone.org/cn
     deploy:
       replicas: 1

--- a/setup_girder.py
+++ b/setup_girder.py
@@ -49,11 +49,9 @@ r = requests.post(
     api_url + "/assetstore",
     headers=headers,
     params={
-        "type": 1,
-        "name": "GridFS",
-        "db": "gridfs",
-        "shard": False,
-        "replicaset": None,
+        "type": 0,
+        "name": "Base",
+        "root": "/tmp/data/base",
     },
 )
 
@@ -64,6 +62,7 @@ plugins = [
     "jobs",
     "worker",
     "globus_handler",
+    "virtual_resources",
     "wt_data_manager",
     "wholetale",
     "wt_home_dir",
@@ -126,6 +125,9 @@ settings = [
         "key": "wholetale.dataverse_extra_hosts",
         "value": ["dev2.dataverse.org", "demo.dataverse.org"],
     },
+    {"key": "dm.private_storage_path", "value": "/tmp/data/ps"},
+    {"key": "wthome.homedir_root", "value": "/tmp/data/homes"},
+    {"key": "wthome.taledir_root", "value": "/tmp/data/workspaces"},
 ]
 
 r = requests.put(
@@ -303,4 +305,7 @@ r = requests.post(api_url + '/image', headers=headers,
 r.raise_for_status()
 image = r.json()
 
+print("Restarting girder to update WebDav roots")
+r = requests.put(api_url + "/system/restart", headers=headers)
+r.raise_for_status()
 final_msg()


### PR DESCRIPTION
### Rationale

This is a fairly substantial overhaul of the way we treat Home/Workspace directories. Instead of keeping all the files from Home/Workspace in Girder's db, we use actual posix file hierarchy to track objects' relations and only mock girder specific objects (Items, Folder) on demand. It's being handled by a completely new plugin: `virtual_resources`.

Complementary PRs:
* https://github.com/whole-tale/wt_home_dirs/pull/29
* https://github.com/whole-tale/girder_wholetale/pull/426

### Test plan
1. Checkout (I'd recommend fresh clone), update wt_home_dirs and wholetale to match PR 29 and 426 respectively
1. Deploy
1. Register Ligo
   * Verify that files are in place:
   ```
   $ tree volumes/
   volumes/ 
   ├── base
   │   └── temp
   ├── homes
   ├── ps
   └── workspaces
       └── 5
           └── 5f4e8277366f6880ded52de9
               ├── environment.yml
               ├── LOSC_Event_tutorial.ipynb
               └── readligo.py
   
   7 directories, 3 files
   ```
1. Login to dashboard, and copy and launch LIGO Tale
   * Verify that files are present in the copied workspace:
   ```
   $ tree volumes/
   volumes/
   ├── base
   │   └── temp
   ├── homes
   │   └── k
   │       └── kowalikk
   ├── ps
   └── workspaces
       └── 5
           ├── 5f4e8277366f6880ded52de9
           │   ├── environment.yml
           │   ├── LOSC_Event_tutorial.ipynb
           │   └── readligo.py
           └── 5f4e82ea366f6880ded52df8
               ├── environment.yml
               ├── LOSC_Event_tutorial.ipynb
               └── readligo.py
   ```

1. Navigate to your LIGO Tale > View > Files > Home and perform basic operations:
   1. Upload a file
   1. Create a folder
   1. Upload a file to the created folder
   1. Verify the content of `volumes/home`:
   ```
   $ tree volumes/homes
   volumes/homes
   └── k
       └── kowalikk
           ├── foo_lin_Slice_z_noise3.png
           └── test_folder
               └── Olaf_invoice_202007.pdf
 
   3 directories, 2 files
   ```
1. Check that both workspace and home files are accessible from a running container
1. Using swagger page export tale (GET /tale/:id/export) as both bagit and native format
   1. Verify that both zipballs contain workspace files
   1. Inspect metadata/manifest.json in the bag and confirm that workspace related files in `aggregates` have proper
      sizes and mimetypes
