### PR TITLE
MATLAB support

### DIFF
--- a/run_worker.sh
+++ b/run_worker.sh
@@ -5,6 +5,7 @@ role=manager,celery
 image=wholetale/gwvolman:latest
 registry_user=fido
 registry_pass=secretpass
+matlab_file_installation_key=secretkey
 node_id=$(docker info --format "{{.Swarm.NodeID}}")
 celery_args="-Q ${role},${node_id} --hostname=${node_id} -c 3"
 
@@ -28,12 +29,14 @@ docker run \
     -e REGISTRY_URL=https://registry.${domain} \
     -e REGISTRY_PASS=${registry_pass} \
     -e WT_LICENSE_PATH="$PWD"/volumes/licenses \
+    -e MATLAB_FILE_INSTALLATION_KEY=${matlab_file_installation_key} \
     -v /var/run/docker.sock:/var/run/docker.sock:ro \
     -v /:/host \
     -v /var/cache/davfs2:/var/cache/davfs2 \
     -v /run/mount.davfs:/run/mount.davfs \
     -v $PWD/src/gwvolman:/gwvolman \
     -v $PWD/src/girderfs:/girderfs \
+    -v $PWD/licenses/:/licenses/ \
     --device /dev/fuse \
     --cap-add SYS_ADMIN \
     --cap-add SYS_PTRACE \

--- a/run_worker.sh
+++ b/run_worker.sh
@@ -36,7 +36,7 @@ docker run \
     -v /run/mount.davfs:/run/mount.davfs \
     -v $PWD/src/gwvolman:/gwvolman \
     -v $PWD/src/girderfs:/girderfs \
-    -v $PWD/licenses/:/licenses/ \
+    -v "$PWD"/volumes/licenses/:/licenses/ \
     --device /dev/fuse \
     --cap-add SYS_ADMIN \
     --cap-add SYS_PTRACE \

--- a/setup_girder.py
+++ b/setup_girder.py
@@ -328,16 +328,16 @@ i_params = {
         'memLimit': '2048m',
         'port': 8888,
         'targetMount': '/home/jovyan/work',
-        'urlPath': '?token={token}',
+        'urlPath': 'lab?token={token}',
         'buildpack': 'MatlabBuildPack',
         'user': 'jovyan'
     }),
     'icon': (
-        'https://raw.githubusercontent.com/whole-tale/jupyter-base/master/'
-        'squarelogo-greytext-orangebody-greymoons.png'
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/2/21/'
+        'Matlab_Logo.png/267px-Matlab_Logo.png'
     ),
     'iframe': True,
-    'name': 'Jupyter with Matlab (R2019b)',
+    'name': 'MATLAB (Jupyter)',
     'public': True
 }
 r = requests.post(api_url + '/image', headers=headers,
@@ -363,11 +363,11 @@ i_params = {
         'user': 'jovyan'
     }),
     'icon': (
-        'https://raw.githubusercontent.com/whole-tale/jupyter-base/master/'
-        'squarelogo-greytext-orangebody-greymoons.png'
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/2/21/'
+        'Matlab_Logo.png/267px-Matlab_Logo.png'
     ),
     'iframe': True,
-    'name': 'Matlab R2019b (Xpra)',
+    'name': 'MATLAB (Desktop)',
     'public': True
 }
 r = requests.post(api_url + '/image', headers=headers,

--- a/setup_girder.py
+++ b/setup_girder.py
@@ -313,6 +313,38 @@ r = requests.post(api_url + '/image', headers=headers,
 r.raise_for_status()
 image = r.json()
 
+print('Create Jupyter with Matlab image')
+i_params = {
+    'config': json.dumps({
+        'command': (
+            'jupyter notebook --no-browser --port {port} --ip=0.0.0.0 '
+            '--NotebookApp.token={token} --NotebookApp.base_url=/{base_path} '
+            '--NotebookApp.port_retries=0'
+        ),
+        'environment': [
+            'CSP_HOSTS=dashboard.local.wholetale.org',
+            'VERSION=R2019b'
+        ],
+        'memLimit': '2048m',
+        'port': 8888,
+        'targetMount': '/home/jovyan/work',
+        'urlPath': '?token={token}',
+        'buildpack': 'MatlabBuildPack',
+        'user': 'jovyan'
+    }),
+    'icon': (
+        'https://raw.githubusercontent.com/whole-tale/jupyter-base/master/'
+        'squarelogo-greytext-orangebody-greymoons.png'
+    ),
+    'iframe': True,
+    'name': 'Jupyter with Matlab (R2019b)',
+    'public': True
+}
+r = requests.post(api_url + '/image', headers=headers,
+                  params=i_params)
+r.raise_for_status()
+image = r.json()
+
 print("Restarting girder to update WebDav roots")
 r = requests.put(api_url + "/system/restart", headers=headers)
 r.raise_for_status()

--- a/setup_girder.py
+++ b/setup_girder.py
@@ -322,8 +322,7 @@ i_params = {
             '--NotebookApp.port_retries=0'
         ),
         'environment': [
-            'CSP_HOSTS=dashboard.local.wholetale.org',
-            'VERSION=R2019b'
+            'VERSION=R2020b'
         ],
         'memLimit': '2048m',
         'port': 8888,
@@ -337,7 +336,7 @@ i_params = {
         'Matlab_Logo.png/267px-Matlab_Logo.png'
     ),
     'iframe': True,
-    'name': 'MATLAB (Jupyter)',
+    'name': 'MATLAB (Jupyter Kernel)',
     'public': True
 }
 r = requests.post(api_url + '/image', headers=headers,
@@ -352,8 +351,7 @@ i_params = {
             'xpra start --bind-tcp=0.0.0.0:10000 --html=on --daemon=no --exit-with-children=no --start-after-connect="matlab -desktop"'
         ),
         'environment': [
-            'CSP_HOSTS=dashboard.local.wholetale.org',
-            'VERSION=R2019b'
+            'VERSION=R2020b '
         ],
         'memLimit': '2048m',
         'port': 10000,
@@ -361,6 +359,36 @@ i_params = {
         'urlPath': '/',
         'buildpack': 'MatlabBuildPack',
         'user': 'jovyan'
+    }),
+    'icon': (
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/2/21/'
+        'Matlab_Logo.png/267px-Matlab_Logo.png'
+    ),
+    'iframe': True,
+    'name': 'MATLAB (Linux Desktop)',
+    'public': True
+}
+r = requests.post(api_url + '/image', headers=headers,
+                  params=i_params)
+r.raise_for_status()
+image = r.json()
+
+print('Create Matlab Web Desktop image')
+i_params = {
+    'config': json.dumps({
+        'command': (
+            'matlab-jupyter-app'
+        ),
+        'environment': [
+            'VERSION=R2020b'
+        ],
+        'memLimit': '2048m',
+        'port': 8888,
+        'targetMount': '/home/jovyan/work',
+        'urlPath': 'matlab/index.html',
+        'buildpack': 'MatlabBuildPack',
+        'user': 'jovyan',
+        'csp': "default-src 'self' *.mathworks.com:*; style-src 'self' 'unsafe-inline' *.mathworks.com:*; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.mathworks.com:*; img-src 'self' *.mathworks.com:* data:; frame-ancestors 'self' *.mathworks.com:* dashboard.local.wholetale.org; frame-src 'self' *.mathworks.com:*; connect-src 'self' *.mathworks.com:* wss://localhost:* wss://127.0.0.1:*"
     }),
     'icon': (
         'https://upload.wikimedia.org/wikipedia/commons/thumb/2/21/'

--- a/setup_girder.py
+++ b/setup_girder.py
@@ -345,6 +345,36 @@ r = requests.post(api_url + '/image', headers=headers,
 r.raise_for_status()
 image = r.json()
 
+print('Create Matlab Xpra image')
+i_params = {
+    'config': json.dumps({
+        'command': (
+            'xpra start --bind-tcp=0.0.0.0:10000 --html=on --daemon=no --exit-with-children=no --start-after-connect="matlab -desktop"'
+        ),
+        'environment': [
+            'CSP_HOSTS=dashboard.local.wholetale.org',
+            'VERSION=R2019b'
+        ],
+        'memLimit': '2048m',
+        'port': 10000,
+        'targetMount': '/home/jovyan/work',
+        'urlPath': '/',
+        'buildpack': 'MatlabBuildPack',
+        'user': 'jovyan'
+    }),
+    'icon': (
+        'https://raw.githubusercontent.com/whole-tale/jupyter-base/master/'
+        'squarelogo-greytext-orangebody-greymoons.png'
+    ),
+    'iframe': True,
+    'name': 'Matlab R2019b (Xpra)',
+    'public': True
+}
+r = requests.post(api_url + '/image', headers=headers,
+                  params=i_params)
+r.raise_for_status()
+image = r.json()
+
 print("Restarting girder to update WebDav roots")
 r = requests.put(api_url + "/system/restart", headers=headers)
 r.raise_for_status()

--- a/setup_girder.py
+++ b/setup_girder.py
@@ -351,7 +351,7 @@ i_params = {
             'xpra start --bind-tcp=0.0.0.0:10000 --html=on --daemon=no --exit-with-children=no --start-after-connect="matlab -desktop"'
         ),
         'environment': [
-            'VERSION=R2020b '
+            'VERSION=R2020b'
         ],
         'memLimit': '2048m',
         'port': 10000,


### PR DESCRIPTION
## Problem

This and related PRs (see below) add support for the creation of MATLAB-based tales.

Fixes https://github.com/whole-tale/whole-tale/issues/85

## Approach
* Create base MATLAB image(s) containing complete installation media (~20GB ISO)
* Modify `repo2docker` (https://github.com/whole-tale/repo2docker/pull/3) to support Docker [buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/), specifically `RUN --mount`. This allows us to build smaller customizable images based on the large install image and requires upgrading infrastructure to Docker version > v18.06 with daemon in experimental mode. This unfortunately required using CLI in place of `docker-py`.
* Modify `repo2docker` (https://github.com/whole-tale/repo2docker/pull/3)  to allow buildpacks to specify `ARG` commands and for build operation to support `--build-arg`. This allows us to pass a secret MATLAB FILE_INSTALLATION_KEY at build time.
* Add `MatlabBuildPack` to `repo2docker_wholetale` (https://github.com/whole-tale/repo2docker_wholetale/pull/14) based on the Matworks "reference" https://github.com/mathworks-ref-arch/matlab-dockerfile/.
* Modify `gwvolman` (https://github.com/whole-tale/gwvolman/pull/117) to support specifying file installation key at build time and mounting licenses directory at runtime

## Required PRs/repos

* https://github.com/whole-tale/matlab-install
* https://github.com/whole-tale/repo2docker/pull/3
* https://github.com/whole-tale/repo2docker_wholetale/pull/14
* https://github.com/whole-tale/gwvolman/pull/117

## How to test

Note: All of this is available on my TACC dev VM. If you want to bypass any step (e.g., downloading media, etc), you can have the keys.

1. Prerequisites:
    1. ~100GB of disk space (20GB for install ISO, 20GB for install Docker image, 20GB for context, 20GB for intermediate image, 20GB just because)
   2. Confirm that you are running newer release of Docker (ideally 19.03.x) that supports buildkit, onfigure Docker daemon to run in  [experimental mode](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md)
   3. Build `matlab-install:R2019b` image based on https://github.com/whole-tale/matlab-install. This will require access to/downloading the MATLAB R2019b ISO image.
   4. Checkout and build https://github.com/whole-tale/repo2docker/pull/3 and https://github.com/whole-tale/repo2docker_wholetale/pull/14 or use `craigwillis/repo2docker_wholetale:matlab` (based on `craigwillis/repo2docker:buildkit`) image. Configure `gwvolman` to use this image
  5.  Configure `FILE_INSTALLATION_KEY` in `run_worker.sh`
  6. Create `licenses/matlab/network.lic` with suitable network license (IU, TACC, UIUC?). 
2. Clone this branch and `make clean & make dev`
  1. Expected output: you should have a new `JupyterLab with MATLAB (R2019b)` environment
3. Create a new tale `Matlab test` selecting `JupyterLab with MATLAB (R2019b)` and upload the notebook and `toolboxes.txt` from https://github.com/craig-willis/matlab-example to the workspace.
4. Build the tale image, which will take a painfully long time the first time 
5. Open the notebook and wait for Matlab kernel to initialize. Run the notebook and confirm output matches https://github.com/craig-willis/matlab-example/blob/main/multiplicative_arima_example.html
6. (Added 11/2/2020) Create a new tale Xpra tests selecting Matlab R2019b (Xpra) and upload the toolboxes.txt and example.m file from https://github.com/craig-willis/matlab-example to the workspace. When running the image, you should get an Xpra-based environment using the HTML5 client. Note that copy-paste doesn't work in iFrame, you must go to full screen and allow clipboard access. In the MATLAB UI select the .m file and "Run." Confirm output matches screenshot.
7. If you want to get fancy, you can test a real dataset from AEA: https://doi.org/10.3886/E111681V1.  This is an example of a MATLAB "tale" that requires the Xpra UI, since figures are displayed.

<img width="1362" alt="Screen Shot 2020-11-02 at 8 32 28 PM" src="https://user-images.githubusercontent.com/4334350/97936762-9173c180-1d4a-11eb-9533-0ab49f3cfa11.png">


# Food for thought
* I didn't port all of repo2docker to CLI, only the build. There could be a better way. 
* Even with buildkit, the build process takes a long time and produces huge images that push slowly to the registry. This is fine for proof of concept, but build speed may be a factor in actual use. 
* An alternative is to build a kitchen-sink image that has all toolboxes and is 20GB. This is fine for us as a cached runtime, but would not be ideal if publishing images externally.




