### PR TITLE
Stata support

### DIFF
--- a/run_worker.sh
+++ b/run_worker.sh
@@ -36,7 +36,6 @@ docker run \
     -v /run/mount.davfs:/run/mount.davfs \
     -v $PWD/src/gwvolman:/gwvolman \
     -v $PWD/src/girderfs:/girderfs \
-    -v "$PWD"/volumes/licenses/:/licenses/ \
     --device /dev/fuse \
     --cap-add SYS_ADMIN \
     --cap-add SYS_PTRACE \

--- a/setup_girder.py
+++ b/setup_girder.py
@@ -403,6 +403,64 @@ r = requests.post(api_url + '/image', headers=headers,
 r.raise_for_status()
 image = r.json()
 
+print('Create Jupyter with Stata image')
+i_params = {
+    'config': json.dumps({
+        'command': (
+            'jupyter notebook --no-browser --port {port} --ip=0.0.0.0 '
+            '--NotebookApp.token={token} --NotebookApp.base_url=/{base_path} '
+            '--NotebookApp.port_retries=0'
+        ),
+        'environment': [
+            'VERSION=16'
+        ],
+        'memLimit': '2048m',
+        'port': 8888,
+        'targetMount': '/home/jovyan/work',
+        'urlPath': 'lab?token={token}',
+        'buildpack': 'StataBuildPack',
+        'user': 'jovyan'
+    }),
+    'icon': (
+        'https://raw.githubusercontent.com/whole-tale/stata-install/main/stata-square.png'
+    ),
+    'iframe': True,
+    'name': 'STATA (Jupyter)',
+    'public': True
+}
+r = requests.post(api_url + '/image', headers=headers,
+                  params=i_params)
+r.raise_for_status()
+image = r.json()
+
+print('Create Stata Xpra image')
+i_params = {
+    'config': json.dumps({
+        'command': (
+            'xpra start --bind-tcp=0.0.0.0:10000 --html=on --daemon=no --exit-with-children=no --start-after-connect=xstata'
+        ),
+        'environment': [
+            'VERSION=16'
+        ],
+        'memLimit': '2048m',
+        'port': 10000,
+        'targetMount': '/home/jovyan/work',
+        'urlPath': '/',
+        'buildpack': 'StataBuildPack',
+        'user': 'jovyan'
+    }),
+    'icon': (
+        'https://raw.githubusercontent.com/whole-tale/stata-install/main/stata-square.png'
+    ),
+    'iframe': True,
+    'name': 'STATA (Desktop)',
+    'public': True
+}
+r = requests.post(api_url + '/image', headers=headers,
+                  params=i_params)
+r.raise_for_status()
+image = r.json()
+
 print("Restarting girder to update WebDav roots")
 r = requests.put(api_url + "/system/restart", headers=headers)
 r.raise_for_status()


### PR DESCRIPTION
## Problem

This and related PRs (see below) add support for the creation of Stata-based tales.

Fixes https://github.com/whole-tale/whole-tale/issues/84

## Approach
* Create base Stata image(s) containing pre-installed core software
* Requires  `repo2docker` buildkit support (https://github.com/whole-tale/repo2docker/pull/3)
* Add `StataBuildPack` to `repo2docker_wholetale` (https://github.com/whole-tale/repo2docker_wholetale/pull/15). This includes support for both Jupyter/Kernel based and Xpra environments.
* Modify `gwvolman` (https://github.com/whole-tale/gwvolman/pull/120) to support mounting month-based license at runtime

## Required PRs/repos

* https://github.com/whole-tale/stata-install
* https://github.com/whole-tale/repo2docker/pull/3
* https://github.com/whole-tale/repo2docker_wholetale/pull/15
* https://github.com/whole-tale/gwvolman/pull/120

## How to test

1. Prerequisites:
   1. Confirm that you are running newer release of Docker (ideally 19.03.x) that supports buildkit, onfigure Docker daemon to run in  [experimental mode](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md)
   2. Build `stata-install:16` image based on https://github.com/whole-tale/stata-install. This will require access to/downloading the  Stata installer for Linux (contact me).
   3. Checkout and build https://github.com/whole-tale/repo2docker/pull/3 and https://github.com/whole-tale/repo2docker_wholetale/pull/15 or use `craigwillis/repo2docker_wholetale:stata` (based on `craigwillis/repo2docker:buildkit`) image. Configure `gwvolman` to use this image
  6. Create `/licenses/stata/stataMM.lic` with a valid license (contact me)
2. Clone this branch and `make clean & make dev`
  1. Expected output: you should have two new images `JupyterLab with Stata (16)` and `Stata 16 (Xpra)`
3. Create a new tale `Stata test` selecting `JupyterLab with Stata (16)` and upload the example.ipynb notebook from https://github.com/whole-tale/stata-example to the workspace.
4. Build the tale image
5. Open the notebook and wait for Stata kernel to initialize. Run the notebook and confirm output matches https://github.com/whole-tale/stata-example/blob/main/example.html
6. Create a new tale Xpra tests selecting Stata 16(Xpra) and upload the example.do file from https://github.com/whole-tale/stata-example to the workspace. When running the image, you should get an Xpra-based environment using the HTML5 client. Note that copy-paste doesn't work in iFrame, you must go to full screen and allow clipboard access.  In the Stata UI select "File > Do..." and select the "Example.do" file. Confirm output matches screenshot below.

<img width="1361" alt="Screen Shot 2020-11-02 at 2 09 09 PM" src="https://user-images.githubusercontent.com/4334350/97908673-ff04fb00-1d14-11eb-9c48-120849e4827a.png">


# Food for thought
* I'm not sure whether we should have one buildpack that supports both Kernel and Xpra or two different buildpacks.
* If we decided to support Xpra, there are some annoyances (copy paste works, but not in iframe, so we may need some additional messaging; the Xpra HTML5 client splash screen is lame and can be customized; there's no terminal in Stata or the Xpra image, but this may not be a big deal since Stata users may not use terminals. 
* We could optionally provide a full Linux desktop


