### PR TITLE
Add support for authentication and authorization of user accessing instances

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -21,41 +21,6 @@ services:
       - GODADDY_API_KEY=$WT_GODADDY_API_KEY
       - GODADDY_API_SECRET=$WT_GODADDY_API_SECRET
 
-  notforyou:
-    image: containous/whoami
-    networks:
-      - traefik-net
-    deploy:
-      replicas: 1
-      labels:
-        - "traefik.enable=true"
-        - "traefik.http.routers.notforyou.rule=Host(`notforyou.local.wholetale.org`)"
-        - "traefik.http.routers.notforyou.entrypoints=websecure"
-        - "traefik.http.routers.notforyou.tls=true"
-        - "traefik.docker.network=wt_traefik-net"
-        - "traefik.http.services.notforyou.loadbalancer.server.port=80"
-        - "traefik.http.services.notforyou.loadbalancer.passhostheader=true"
-        - "traefik.http.routers.notforyou.middlewares=girder"
-
-  whoami:
-    image: containous/whoami
-    networks:
-      - traefik-net
-    deploy:
-      replicas: 1
-      labels:
-        - "traefik.enable=true"
-        - "traefik.http.routers.whoami.rule=Host(`whoami.local.wholetale.org`)"
-        - "traefik.http.routers.whoami.entrypoints=websecure"
-        - "traefik.http.routers.whoami.tls=true"
-        - "traefik.docker.network=wt_traefik-net"
-        - "traefik.http.services.whoami.loadbalancer.server.port=80"
-        - "traefik.http.services.whoami.loadbalancer.passhostheader=true"
-        - "traefik.http.routers.whoami.middlewares=girder,whoami-csp"
-        - "traefik.http.middlewares.whoami-csp.headers.contentSecurityPolicy=frame-ancestor 'self' https://dashboard.local.wholetale.org"
-        - "traefik.http.middlewares.whoami-csp.headers.customResponseHeaders.X-Custom-Response-Header=value"
-
-
   mongo:
     image: mongo:3.2
     networks:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -21,6 +21,22 @@ services:
       - GODADDY_API_KEY=$WT_GODADDY_API_KEY
       - GODADDY_API_SECRET=$WT_GODADDY_API_SECRET
 
+  notforyou:
+    image: containous/whoami
+    networks:
+      - traefik-net
+    deploy:
+      replicas: 1
+      labels:
+        - "traefik.enable=true"
+        - "traefik.http.routers.notforyou.rule=Host(`notforyou.local.wholetale.org`)"
+        - "traefik.http.routers.notforyou.entrypoints=websecure"
+        - "traefik.http.routers.notforyou.tls=true"
+        - "traefik.docker.network=wt_traefik-net"
+        - "traefik.http.services.notforyou.loadbalancer.server.port=80"
+        - "traefik.http.services.notforyou.loadbalancer.passhostheader=true"
+        - "traefik.http.routers.notforyou.middlewares=girder"
+
   whoami:
     image: containous/whoami
     networks:
@@ -85,6 +101,7 @@ services:
         - "traefik.docker.network=wt_traefik-net"
         - "traefik.http.middlewares.girder.forwardauth.address=http://girder:8080/api/v1/instance/authorize/"
         - "traefik.http.middlewares.girder.forwardauth.trustforwardheader=true"
+        - "traefik.http.middlewares.girder.forwardauth.authresponseheaders=Set-Cookie"
 
   redis:
     image: redis:4-stretch

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   traefik:
-    image: traefik:alpine
+    image: traefik:v2.4
     ports:
       - "80:80"
       - "443:443"
@@ -15,9 +15,45 @@ services:
       - ./traefik/acme:/acme
     deploy:
       replicas: 1
+      labels:
+        - "traefik.enable=false"
     environment:
       - GODADDY_API_KEY=$WT_GODADDY_API_KEY
       - GODADDY_API_SECRET=$WT_GODADDY_API_SECRET
+
+  #traefik-forward-auth:
+  #  image: thomseddon/traefik-forward-auth:2
+  #  environment:
+  #    - PROVIDERS_GENERIC_OAUTH_AUTH_URL=https://auth.globus.org/v2/oauth2/authorize
+  #    - PROVIDERS_GENERIC_OAUTH_TOKEN_URL=https://auth.globus.org/v2/oauth2/token
+  #    - PROVIDERS_GENERIC_OAUTH_USER_URL=https://auth.globus.org/v2/oauth2/identities
+  #    - PROVIDERS_GENERIC_OAUTH_SCOPE=urn:globus:auth:scope:auth.globus.org:view_identities openid profile email
+  #    - PROVIDERS_GENERIC_OAUTH_CLIENT_ID=0baa7c04-1ff6-4cf5-82b3-00dd47e828d9
+  #    - PROVIDERS_GENERIC_OAUTH_CLIENT_SECRET=7G7Yc+DWev9h0QFPdCIrAotmoSU2Wc3626+60WNCpk0=
+  #    - SECRET=026a02896709fc5ac412bd820c201b98
+  #  labels:
+  #    - "traefik.http.middlewares.traefik-forward-auth.forwardauth.address=http://traefik-forward-auth:4181"
+  #    - "traefik.http.middlewares.traefik-forward-auth.forwardauth.authResponseHeaders=X-Forwarded-User"
+  #    - "traefik.http.services.traefik-forward-auth.loadbalancer.server.port=4181
+
+  whoami:
+    image: containous/whoami
+    networks:
+      - traefik-net
+    deploy:
+      replicas: 1
+      labels:
+        - "traefik.enable=true"
+        - "traefik.http.routers.whoami.rule=Host(`whoami.local.wholetale.org`)"
+        - "traefik.http.routers.whoami.entrypoints=websecure"
+        - "traefik.http.routers.whoami.tls=true"
+        - "traefik.docker.network=wt_traefik-net"
+        - "traefik.http.services.whoami.loadbalancer.server.port=80"
+        - "traefik.http.services.whoami.loadbalancer.passhostheader=true"
+        - "traefik.http.routers.whoami.middlewares=girder"
+        - "traefik.http.middlewares.whoami.headers.customrequestheaders.X-CustomHeader=test"
+        - "traefik.http.middlewares.whoami.forwardauth.authRequestHeaders=X-CustomHeader"
+
 
   mongo:
     image: mongo:3.2
@@ -28,6 +64,8 @@ services:
       - mongo-cfg:/data/configdb
     deploy:
       replicas: 1
+      labels:
+        - "traefik.enable=false"
 
 
   girder:
@@ -56,12 +94,16 @@ services:
     deploy:
       replicas: 1
       labels:
-        - "traefik.frontend.rule=Host:girder.local.wholetale.org"
-        - "traefik.port=8080"
         - "traefik.enable=true"
+        - "traefik.http.routers.girder.rule=Host(`girder.local.wholetale.org`)"
+        - "traefik.http.routers.girder.entrypoints=websecure"
+        - "traefik.http.routers.girder.tls=true"
+        - "traefik.http.services.girder.loadbalancer.server.port=8080"
+        - "traefik.http.services.girder.loadbalancer.passhostheader=true"
         - "traefik.docker.network=wt_traefik-net"
-        - "traefik.frontend.passHostHeader=true"
-        - "traefik.frontend.entryPoints=https"
+        - "traefik.http.middlewares.girder.forwardauth.address=https://girder.local.wholetale.org/api/v1/instance/authorize/"
+        - "traefik.http.middlewares.girder.forwardauth.trustforwardheader=true"
+        - "traefik.http.middlewares.girder.forwardauth.authRequestHeaders=X-CustomHeader"
 
   redis:
     image: redis:4-stretch
@@ -71,28 +113,6 @@ services:
       replicas: 1
       labels:
         - "traefik.enable=false"
-
-  dashboard_old:
-    image: wholetale/dashboardproxy:latest
-    # build: ./dashboard_local
-    networks:
-      - traefik-net
-    environment:
-      - GIRDER_API_URL=https://girder.local.wholetale.org
-      - AUTH_PROVIDER=Globus
-      - DATAONE_URL=https://cn-stage-2.test.dataone.org
-      - DASHBOARD_DEV=true
-    volumes:
-      - ./src/dashboard/dist:/srv/dashboard
-    deploy:
-      replicas: 1
-      labels:
-        - "traefik.port=80"
-        - "traefik.frontend.rule=Host:legacy.local.wholetale.org"
-        - "traefik.enable=true"
-        - "traefik.docker.network=wt_traefik-net"
-        - "traefik.frontend.passHostHeader=true"
-        - "traefik.frontend.entryPoints=https"
 
   dashboard:
     image: wholetale/ngx-dashboard:latest
@@ -106,12 +126,13 @@ services:
     deploy:
       replicas: 1
       labels:
-        - "traefik.port=80"
-        - "traefik.frontend.rule=Host:dashboard.local.wholetale.org"
         - "traefik.enable=true"
+        - "traefik.http.routers.dashboard.rule=Host(`dashboard.local.wholetale.org`)"
+        - "traefik.http.routers.dashboard.entrypoints=websecure"
+        - "traefik.http.routers.dashboard.tls=true"
+        - "traefik.http.services.dashboard.loadbalancer.server.port=80"
+        - "traefik.http.services.dashboard.loadbalancer.passhostheader=true"
         - "traefik.docker.network=wt_traefik-net"
-        - "traefik.frontend.passHostHeader=true"
-        - "traefik.frontend.entryPoints=https"
     volumes:
       - ./src/ngx-dashboard/dist/browser/:/usr/share/nginx/html/
 
@@ -130,12 +151,13 @@ services:
     deploy:
       replicas: 1
       labels:
-        - "traefik.port=5000"
-        - "traefik.frontend.rule=Host:registry.local.wholetale.org"
         - "traefik.enable=true"
+        - "traefik.http.routers.registry.rule=Host(`registry.local.wholetale.org`)"
+        - "traefik.http.routers.registry.entrypoints=websecure"
+        - "traefik.http.routers.registry.tls=true"
+        - "traefik.http.services.registry.loadbalancer.server.port=5000"
+        - "traefik.http.services.registry.loadbalancer.passhostheader=true"
         - "traefik.docker.network=wt_traefik-net"
-        - "traefik.frontend.passHostHeader=true"
-        - "traefik.frontend.entryPoints=https"
 
 #  celery_worker:
 #    image: wholetale/gwvolman

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -51,7 +51,10 @@ services:
         - "traefik.docker.network=wt_traefik-net"
         - "traefik.http.services.whoami.loadbalancer.server.port=80"
         - "traefik.http.services.whoami.loadbalancer.passhostheader=true"
-        - "traefik.http.routers.whoami.middlewares=girder"
+        - "traefik.http.routers.whoami.middlewares=girder,whoami-csp"
+        - "traefik.http.middlewares.whoami-csp.headers.contentSecurityPolicy=frame-ancestor 'self' https://dashboard.local.wholetale.org"
+        - "traefik.http.middlewares.whoami-csp.headers.customResponseHeaders.X-Custom-Response-Header=value"
+
 
   mongo:
     image: mongo:3.2
@@ -67,7 +70,7 @@ services:
 
 
   girder:
-    image: wholetale/girder:latest
+    image: wholetale/girder:cookie
     networks:
       - traefik-net
       - celery
@@ -101,7 +104,6 @@ services:
         - "traefik.docker.network=wt_traefik-net"
         - "traefik.http.middlewares.girder.forwardauth.address=http://girder:8080/api/v1/instance/authorize/"
         - "traefik.http.middlewares.girder.forwardauth.trustforwardheader=true"
-        - "traefik.http.middlewares.girder.forwardauth.authresponseheaders=Set-Cookie"
 
   redis:
     image: redis:4-stretch

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -21,21 +21,6 @@ services:
       - GODADDY_API_KEY=$WT_GODADDY_API_KEY
       - GODADDY_API_SECRET=$WT_GODADDY_API_SECRET
 
-  #traefik-forward-auth:
-  #  image: thomseddon/traefik-forward-auth:2
-  #  environment:
-  #    - PROVIDERS_GENERIC_OAUTH_AUTH_URL=https://auth.globus.org/v2/oauth2/authorize
-  #    - PROVIDERS_GENERIC_OAUTH_TOKEN_URL=https://auth.globus.org/v2/oauth2/token
-  #    - PROVIDERS_GENERIC_OAUTH_USER_URL=https://auth.globus.org/v2/oauth2/identities
-  #    - PROVIDERS_GENERIC_OAUTH_SCOPE=urn:globus:auth:scope:auth.globus.org:view_identities openid profile email
-  #    - PROVIDERS_GENERIC_OAUTH_CLIENT_ID=0baa7c04-1ff6-4cf5-82b3-00dd47e828d9
-  #    - PROVIDERS_GENERIC_OAUTH_CLIENT_SECRET=7G7Yc+DWev9h0QFPdCIrAotmoSU2Wc3626+60WNCpk0=
-  #    - SECRET=026a02896709fc5ac412bd820c201b98
-  #  labels:
-  #    - "traefik.http.middlewares.traefik-forward-auth.forwardauth.address=http://traefik-forward-auth:4181"
-  #    - "traefik.http.middlewares.traefik-forward-auth.forwardauth.authResponseHeaders=X-Forwarded-User"
-  #    - "traefik.http.services.traefik-forward-auth.loadbalancer.server.port=4181
-
   whoami:
     image: containous/whoami
     networks:
@@ -51,9 +36,6 @@ services:
         - "traefik.http.services.whoami.loadbalancer.server.port=80"
         - "traefik.http.services.whoami.loadbalancer.passhostheader=true"
         - "traefik.http.routers.whoami.middlewares=girder"
-        - "traefik.http.middlewares.whoami.headers.customrequestheaders.X-CustomHeader=test"
-        - "traefik.http.middlewares.whoami.forwardauth.authRequestHeaders=X-CustomHeader"
-
 
   mongo:
     image: mongo:3.2
@@ -101,9 +83,8 @@ services:
         - "traefik.http.services.girder.loadbalancer.server.port=8080"
         - "traefik.http.services.girder.loadbalancer.passhostheader=true"
         - "traefik.docker.network=wt_traefik-net"
-        - "traefik.http.middlewares.girder.forwardauth.address=https://girder.local.wholetale.org/api/v1/instance/authorize/"
+        - "traefik.http.middlewares.girder.forwardauth.address=http://girder:8080/api/v1/instance/authorize/"
         - "traefik.http.middlewares.girder.forwardauth.trustforwardheader=true"
-        - "traefik.http.middlewares.girder.forwardauth.authRequestHeaders=X-CustomHeader"
 
   redis:
     image: redis:4-stretch

--- a/run_worker.sh
+++ b/run_worker.sh
@@ -24,7 +24,7 @@ docker run \
     -e DEV=true \
     -e DOMAIN=${domain} \
     -e TRAEFIK_NETWORK=wt_traefik-net \
-    -e TRAEFIK_ENTRYPOINT=https \
+    -e TRAEFIK_ENTRYPOINT=websecure \
     -e REGISTRY_USER=${registry_user} \
     -e REGISTRY_URL=https://registry.${domain} \
     -e REGISTRY_PASS=${registry_pass} \

--- a/setup_girder.py
+++ b/setup_girder.py
@@ -107,6 +107,7 @@ settings = [
             "X-Forwarded-Host, Remote-Addr, Cache-Control"
         ),
     },
+    {"key": "core.cookie_domain", "value": ".local.wholetale.org"},
     {"key": "worker.api_url", "value": "http://girder:8080/api/v1"},
     {"key": "worker.broker", "value": "redis://redis/"},
     {"key": "worker.backend", "value": "redis://redis/"},

--- a/traefik/traefik.toml
+++ b/traefik/traefik.toml
@@ -1,69 +1,69 @@
-graceTimeOut = "10s"
-debug = false
-checkNewVersion = false
-logLevel = "INFO"
-
-# If set to true invalid SSL certificates are accepted for backends.
-# Note: This disables detection of man-in-the-middle attacks so should only be used on secure backend networks.
-# Optional
-# Default: false
-#
-# InsecureSkipVerify = true
-
-defaultEntryPoints = ["http", "https"]
-
 [entryPoints]
-  [entryPoints.http]
-  address = ":80"
-    [entryPoints.http.redirect]
-       entryPoint = "https"
-  [entryPoints.https]
-  address = ":443"
-    [entryPoints.https.tls]
-    #MinVersion = "VersionTLS12"
-    #CipherSuites = ["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"]
-    MinVersion = "VersionTLS10"
-    CipherSuites = ["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"]
+  [entryPoints.web]
+    address = ":80"
+    [entryPoints.web.http]
+      [entryPoints.web.http.redirections]
+        [entryPoints.web.http.redirections.entryPoint]
+          to = "websecure"
+          scheme = "https"
 
-[web]
-address = ":8080"
+  [entryPoints.websecure]
+    address = ":443"
 
-[acme]
-email = "bgates@microsoft.com"   # FIXME
-storage = "/acme/acme.json"
-entryPoint = "https"
-acmeLogging = true
+[providers]
+  providersThrottleDuration = "2s"
+  [providers.docker]
+    watch = true
+    endpoint = "unix:///var/run/docker.sock"
+    exposedByDefault = true
+    swarmMode = true
+    swarmModeRefreshSeconds = "15s"
+    httpClientTimeout = "0s"
+    defaultRule = "Host(`{{ trimPrefix `/` .Name }}.local.wholetale.org`)"
 
-[acme.dnsChallenge]
-provider = "godaddy"
-delayBeforeCheck = 1800
+[tls.options]
+  [tls.options.default]
+    minVersion = "VersionTLS10"
+    cipherSuites = [
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+      "TLS_RSA_WITH_AES_128_CBC_SHA",
+      "TLS_RSA_WITH_AES_256_CBC_SHA"
+   ]
 
-[[acme.domains]]
-main = "*.local.wholetale.org"
+[api]
+  debug = false
+  dashboard = true
+  insecure = true
 
-[docker]
-endpoint = "unix:///var/run/docker.sock"
-domain = "local.wholetale.org"
-watch = true
-exposedbydefault = true
-swarmmode = true
+[log]
+  level = "INFO"
 
 [accessLog]
-  filePath = "/etc/traefik/access.log"
   format = "json"
-
+  bufferingSize = 0
   [accessLog.filters]
     statusCodes = ["200", "300-302"]
     retryAttempts = true
-
+    minDuration = "0s"
   [accessLog.fields]
     defaultMode = "keep"
     [accessLog.fields.names]
-      "ClientUsername" = "drop"
-
+      ClientUsername = "drop"
     [accessLog.fields.headers]
       defaultMode = "keep"
       [accessLog.fields.headers.names]
-        "User-Agent" = "redact"
-        "Authorization" = "drop"
-        "Content-Type" = "keep"
+        Authorization = "drop"
+        Content-Type = "keep"
+        User-Agent = "redact"
+
+[certificatesResolvers]
+  [certificatesResolvers.default]
+    [certificatesResolvers.default.acme]
+      email = "bgates@microsoft.com"
+      storage = "/acme/acme.json"
+      [certificatesResolvers.default.acme.dnsChallenge]
+        provider = "godaddy"
+        delayBeforeCheck = "30m0s"
+        #entryPoint = "https"

--- a/traefik/traefik.toml
+++ b/traefik/traefik.toml
@@ -38,7 +38,7 @@
   insecure = true
 
 [log]
-  level = "INFO"
+  level = "DEBUG"
 
 [accessLog]
   format = "json"


### PR DESCRIPTION
**Problem/Approach**:
See https://github.com/whole-tale/whole-tale/issues/94

**Prerequisites**:
* Ask me for the v2 `acme.json` or download https://github.com/traefik/traefik-migration-tool, `cd deploy-dev/traefik/acme` and run `sudo traefik-migration-tool acme` to convert the `acme.json` to v2
* Requires this branch, https://github.com/whole-tale/gwvolman/pull/135, and https://github.com/whole-tale/girder_wholetale/pull/454
 
**Test case**:
* Go to https://dashboard.local.wholetale.org
* Create a tale and start the instance
* Confirm that the instance can be accessed via iframe and pop-out tab
* Open the pop-out tab URL in a private/incognito session 
* Confirm that you are redirected through the oauth flow and can access the instance
* Open the pop-out tab URL in a new private/incognito session for another user
* Confirm that you get a 403 error (`Access denied for instance`)
