### PR TITLE
Change order of gwvolman install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,10 @@ dev: services
 	    cid=$$(docker ps --filter=name=wt_girder -q) ; \
 	done; \
 	true
-	docker exec --user=root -ti $$(docker ps --filter=name=wt_girder -q) pip install -e /girderfs
-	docker exec --user=root -ti $$(docker ps --filter=name=wt_girder -q) pip install -r /gwvolman/requirements.txt -e /gwvolman
 	docker exec -ti $$(docker ps --filter=name=wt_girder -q) girder-install plugin plugins/wt_data_manager plugins/wholetale plugins/wt_home_dir plugins/globus_handler plugins/virtual_resources plugins/wt_versioning
 	docker exec -ti $$(docker ps --filter=name=wt_girder -q) girder-install web --dev --plugins=oauth,gravatar,jobs,worker,wt_data_manager,wholetale,wt_home_dir,globus_handler
+	docker exec --user=root -ti $$(docker ps --filter=name=wt_girder -q) pip install -r /gwvolman/requirements.txt -e /gwvolman
+	docker exec --user=root -ti $$(docker ps --filter=name=wt_girder -q) pip install -e /girderfs
 	./setup_girder.py
 
 restart_girder:


### PR DESCRIPTION
**Problem**:
For some reason the wrong version of `gwvolman` is used by Girder resulting in the following error:
```
{
  "message": "TypeError: TypeError(\"publish() got multiple values for argument 'repository'\")",
  "trace": [
    "<FrameSummary file /girder/girder/api/rest.py, line 630 in endpointDecorator>",
    "<FrameSummary file /girder/girder/api/rest.py, line 1231 in PUT>",
    "<FrameSummary file /girder/girder/api/rest.py, line 970 in handleRoute>",
    "<FrameSummary file /girder/girder/api/access.py, line 63 in wrapped>",
    "<FrameSummary file /girder/girder/api/rest.py, line 445 in wrapped>",
    "<FrameSummary file /girder/girder/api/describe.py, line 709 in wrapped>",
    "<FrameSummary file /girder/plugins/wholetale/server/rest/tale.py, line 623 in publishTale>",
    "<FrameSummary file /usr/local/lib/python3.7/dist-packages/celery/app/task.py, line 424 in delay>",
    "<FrameSummary file /usr/local/lib/python3.7/dist-packages/girder_worker/task.py, line 107 in apply_async>",
    "<FrameSummary file /usr/local/lib/python3.7/dist-packages/celery/app/task.py, line 529 in apply_async>"
  ],
  "type": "internal"
}
```


**Approach**:
Assume something has changed with pip and re-order the pip install during `make dev`