### PR TITLE
Add proxied route for vocabularies.local.wholetale.org

### DIFF
--- a/traefik/traefik.toml
+++ b/traefik/traefik.toml
@@ -20,6 +20,9 @@
     swarmModeRefreshSeconds = "15s"
     httpClientTimeout = "0s"
     defaultRule = "Host(`{{ trimPrefix `/` .Name }}.local.wholetale.org`)"
+  [providers.file]
+    path=/etc/traefik/vocab.toml
+    watch=true
 
 [tls.options]
   [tls.options.default]

--- a/traefik/traefik.toml
+++ b/traefik/traefik.toml
@@ -21,7 +21,7 @@
     httpClientTimeout = "0s"
     defaultRule = "Host(`{{ trimPrefix `/` .Name }}.local.wholetale.org`)"
   [providers.file]
-    path=/etc/traefik/vocab.toml
+    filename="/etc/traefik/vocab.toml"
     watch=true
 
 [tls.options]

--- a/traefik/vocab.toml
+++ b/traefik/vocab.toml
@@ -1,0 +1,19 @@
+[http]
+  [http.routers]
+    [http.routers.vocabularies]
+      rule="Host(`vocabularies.local.wholetale.org`)"
+      service="vocabularies"
+      entryPoints=["web", "websecure"]
+      middlewares=["repo-prefix"]
+      tls = true
+
+  [http.middlewares]
+    [http.middlewares.repo-prefix.addPrefix]
+      prefix = "/serialization-format"
+
+  [http.services]
+    [http.services.vocabularies]
+      [http.services.vocabularies.loadBalancer]
+        passHostHeader = false
+        [[http.services.vocabularies.loadBalancer.servers]]
+          url="https://whole-tale.github.io/"


### PR DESCRIPTION
See https://github.com/whole-tale/whole-tale/issues/95 for problem description

This PR adds configuration to traefik to proxy requests from `vocabularies.local.wholetale.org` to `whole-tale.github.io//serialization-format` GH-pages site.

**To Test**:
* `make dev` with this branch
* Go to https://vocabularies.local.wholetale.org/wt/1.0/index.html
* Confirm that it matches https://whole-tale.github.io/serialization-format/wt/1.0/

