### PR TITLE
Fix default GIRDER_API_URL

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -84,7 +84,7 @@ services:
     networks:
       - traefik-net
     environment:
-      - GIRDER_API_URL=https://girder.local.wholetale.org
+      - GIRDER_API_URL=https://girder.local.wholetale.org/api/v1
       - AUTH_PROVIDER=Globus
       - DATAONE_URL=https://cn-stage-2.test.dataone.org
       - DASHBOARD_DEV=true


### PR DESCRIPTION
This is required to test https://github.com/whole-tale/ngx-dashboard/pull/146