### PR TITLE
Add RTD_URL to ngx-dashboard

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -86,7 +86,8 @@ services:
     environment:
       - GIRDER_API_URL=https://girder.local.wholetale.org/api/v1
       - AUTH_PROVIDER=Globus
-      - DATAONE_URL=https://cn-stage-2.test.dataone.org
+      - DATAONE_URL=https://cn-stage-2.test.dataone.org/v2
+      - RTD_URL=https://wholetale.readthedocs.io/en/latest
       - DASHBOARD_DEV=true
     deploy:
       replicas: 1


### PR DESCRIPTION
Adds `RTD_URL` to ngx-dashboard for https://github.com/whole-tale/ngx-dashboard/pull/165. See test case there.