### PR TITLE
Setup for idle instance handling

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -35,7 +35,7 @@ services:
 
 
   girder:
-    image: wholetale/girder:heartbeat
+    image: wholetale/girder:latest
     networks:
       - traefik-net
       - celery

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -35,7 +35,7 @@ services:
 
 
   girder:
-    image: wholetale/girder:latest
+    image: wholetale/girder:heartbeat
     networks:
       - traefik-net
       - celery
@@ -86,7 +86,7 @@ services:
     environment:
       - GIRDER_API_URL=https://girder.local.wholetale.org/api/v1
       - AUTH_PROVIDER=Globus
-      - DATAONE_URL=https://cn-stage-2.test.dataone.org/v2
+      - DATAONE_URL=https://cn.dataone.org/cn/v2
       - RTD_URL=https://wholetale.readthedocs.io/en/latest
       - DASHBOARD_DEV=true
     deploy:
@@ -101,6 +101,25 @@ services:
         - "traefik.docker.network=wt_traefik-net"
     volumes:
       - ./src/ngx-dashboard/dist/browser/:/usr/share/nginx/html/
+  
+  instance-errors:
+    image: wholetale/custom-errors:latest
+    networks:
+      - traefik-net
+    deploy:
+      replicas: 1
+      labels:
+        - "traefik.enable=true"
+        - "traefik.http.routers.instance-errors.rule=HostRegexp(`{host:tmp-.*}`)"
+        - "traefik.http.routers.instance-errors.entrypoints=websecure"
+        - "traefik.http.routers.instance-errors.tls=true"
+        - "traefik.http.routers.instance-errors.priority=1"
+        - "traefik.http.routers.instance-errors.middlewares=error-pages-middleware"
+        - "traefik.http.middlewares.error-pages-middleware.errors.status=400-599"
+        - "traefik.http.middlewares.error-pages-middleware.errors.service=instance-errors"
+        - "traefik.http.middlewares.error-pages-middleware.errors.query=/{status}.html"
+        - "traefik.http.services.instance-errors.loadbalancer.server.port=80"
+        - "traefik.docker.network=wt_traefik-net"
 
   registry:
     image: registry:2.6

--- a/girder/girder.local.cfg
+++ b/girder/girder.local.cfg
@@ -13,3 +13,4 @@ api_root = "/api/v1"
 static_root = "/static"
 api_static_root = "../static"
 cherrypy_server = True
+heartbeat = 300

--- a/setup_girder.py
+++ b/setup_girder.py
@@ -338,7 +338,8 @@ i_params = {
     ),
     'iframe': True,
     'name': 'MATLAB (Jupyter Kernel)',
-    'public': True
+    'public': True,
+    'idleTimeout': 120
 }
 r = requests.post(api_url + '/image', headers=headers,
                   params=i_params)
@@ -367,7 +368,8 @@ i_params = {
     ),
     'iframe': True,
     'name': 'MATLAB (Linux Desktop)',
-    'public': True
+    'public': True,
+    'idleTimeout': 120
 }
 r = requests.post(api_url + '/image', headers=headers,
                   params=i_params)
@@ -397,7 +399,8 @@ i_params = {
     ),
     'iframe': True,
     'name': 'MATLAB (Desktop)',
-    'public': True
+    'public': True,
+    'idleTimeout': 120
 }
 r = requests.post(api_url + '/image', headers=headers,
                   params=i_params)


### PR DESCRIPTION
This PR:
* ~Uses https://github.com/whole-tale/girder/pull/11~
* Adds `heartbeat` girder config
* Adds `idleTimeout` config to MATLAB images in `setup_girder.py`
* Adds `instance-errors` service for custom 404 on culled instance URLs