### PR TITLE
Upgrade NodeJS to v14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ rebuild_dashboard:
 		--entrypoint /bin/sh \
 		-w /srv/app node:fermium \
 			-c 'yarn install --network-timeout=360000 && \
-			./node_modules/@angular/cli/bin/ng build --prod --deleteOutputPath=false --progress --no-aot --build-optimizer false'
+			./node_modules/@angular/cli/bin/ng build --deleteOutputPath=false --progress'
 
 watch_dashboard:
 	docker run \
@@ -108,7 +108,7 @@ watch_dashboard:
 		--entrypoint /bin/sh \
 		node:fermium \
 			-c 'yarn install --network-timeout=360000 && \
-			./node_modules/@angular/cli/bin/ng build --prod --watch --poll 15000 --deleteOutputPath=false --progress --no-aot --build-optimizer false'
+			./node_modules/@angular/cli/bin/ng build --watch --poll 15000 --deleteOutputPath=false --progress'
 
 restart_worker:
 	docker exec --user=root -ti $$(docker ps --filter=name=wt_girder -q) pip install -e /gwvolman

--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,9 @@ rebuild_dashboard:
 		-ti \
 		-e NODE_OPTIONS=--max-old-space-size=4096 \
 		-v $${PWD}/src/ngx-dashboard:/srv/app \
+		--entrypoint /bin/sh \
 		-w /srv/app node:fermium \
-			'yarn install --network-timeout=360000 && \
+			-c 'yarn install --network-timeout=360000 && \
 			./node_modules/@angular/cli/bin/ng build --prod --deleteOutputPath=false --progress --no-aot --build-optimizer false'
 
 watch_dashboard:
@@ -104,8 +105,9 @@ watch_dashboard:
 		-e NODE_OPTIONS=--max-old-space-size=4096 \
 		-v $${PWD}/src/ngx-dashboard:/srv/app \
 		-w /srv/app \
+		--entrypoint /bin/sh \
 		node:fermium \
-			'yarn install --network-timeout=360000 && \
+			-c 'yarn install --network-timeout=360000 && \
 			./node_modules/@angular/cli/bin/ng build --prod --watch --poll 15000 --deleteOutputPath=false --progress --no-aot --build-optimizer false'
 
 restart_worker:

--- a/Makefile
+++ b/Makefile
@@ -91,9 +91,9 @@ rebuild_dashboard:
 		--user=$${UID}:$${GID} \
 		-ti \
 		-v $${PWD}/src/ngx-dashboard:/srv/app \
-		-w /srv/app bodom0015/ng \
+		-w /srv/app node:fermium \
 			'${YARN} install --network-timeout=360000 && \
-			${NG} build --prod --deleteOutputPath=false --progress'
+			${NG} build --prod --deleteOutputPath=false --progress --no-aot --build-optimizer false'
 
 watch_dashboard:
 	docker run \
@@ -102,9 +102,9 @@ watch_dashboard:
 		-ti \
 		-v $${PWD}/src/ngx-dashboard:/srv/app \
 		-w /srv/app \
-		bodom0015/ng \
+		node:fermium \
 			'${YARN} install --network-timeout=360000 && \
-			${NG} build --prod --watch --poll 15000 --deleteOutputPath=false --progress'
+			${NG} build --prod --watch --poll 15000 --deleteOutputPath=false --progress --no-aot --build-optimizer false'
 
 restart_worker:
 	docker exec --user=root -ti $$(docker ps --filter=name=wt_girder -q) pip install -e /gwvolman

--- a/Makefile
+++ b/Makefile
@@ -90,21 +90,23 @@ rebuild_dashboard:
 		--rm \
 		--user=$${UID}:$${GID} \
 		-ti \
+		-e NODE_OPTIONS=--max-old-space-size=4096 \
 		-v $${PWD}/src/ngx-dashboard:/srv/app \
 		-w /srv/app node:fermium \
-			'${YARN} install --network-timeout=360000 && \
-			${NG} build --prod --deleteOutputPath=false --progress --no-aot --build-optimizer false'
+			'yarn install --network-timeout=360000 && \
+			./node_modules/@angular/cli/bin/ng build --prod --deleteOutputPath=false --progress --no-aot --build-optimizer false'
 
 watch_dashboard:
 	docker run \
 		--rm \
 		--user=$${UID}:$${GID} \
 		-ti \
+		-e NODE_OPTIONS=--max-old-space-size=4096 \
 		-v $${PWD}/src/ngx-dashboard:/srv/app \
 		-w /srv/app \
 		node:fermium \
-			'${YARN} install --network-timeout=360000 && \
-			${NG} build --prod --watch --poll 15000 --deleteOutputPath=false --progress --no-aot --build-optimizer false'
+			'yarn install --network-timeout=360000 && \
+			./node_modules/@angular/cli/bin/ng build --prod --watch --poll 15000 --deleteOutputPath=false --progress --no-aot --build-optimizer false'
 
 restart_worker:
 	docker exec --user=root -ti $$(docker ps --filter=name=wt_girder -q) pip install -e /gwvolman


### PR DESCRIPTION
## Problem
Since https://github.com/whole-tale/ngx-dashboard/pull/210 has been merged, `make rebuild_dashboard` for ngx-dashboard is no longer compatible with the NodeJS version installed in the base image, and fails with the following error:
```
error jest-preset-angular@9.0.0: The engine "node" is incompatible with this module. Expected version "^12.13.0 || ^14.15.0 || >=15.0.0". Got "10.22.0"
error Found incompatible module.
```

## Approach
Build with official NodeJS 14 base image instead

* NOTE: This PR temporarily removes `--prod` from `ng build` in `make rebuild_dashboard` - this was causing the dashboard to render a blank page

## How to Test
1. Checkout and run this branch locally
2. Run `make rebuild_dashboard`
    * You should see no red build errors
3. Run `make watch_dashboard`
    * You should see no red build errors