### PR TITLE
Add read-only public registry

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -127,7 +127,6 @@ services:
     image: registry:2.6
     networks:
       - traefik-net
-      - celery
     volumes:
       - ./registry:/var/lib/registry
       - ./registry/auth:/auth:ro
@@ -150,7 +149,6 @@ services:
     image: registry:2.6
     networks:
       - traefik-net
-      - celery
     volumes:
       - ./registry:/var/lib/registry:ro
     deploy:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -33,7 +33,6 @@ services:
       labels:
         - "traefik.enable=false"
 
-
   girder:
     image: wholetale/girder:latest
     networks:
@@ -145,6 +144,25 @@ services:
         - "traefik.http.routers.registry.tls=true"
         - "traefik.http.services.registry.loadbalancer.server.port=5000"
         - "traefik.http.services.registry.loadbalancer.passhostheader=true"
+        - "traefik.docker.network=wt_traefik-net"
+
+  images:
+    image: registry:2.6
+    networks:
+      - traefik-net
+      - celery
+    volumes:
+      - ./registry:/var/lib/registry:ro
+    deploy:
+      replicas: 1
+      labels:
+        - "traefik.enable=true"
+        - "traefik.http.routers.images.rule=Host(`images.local.wholetale.org`)"
+        - "traefik.http.routers.images.rule=Method(`GET`)"
+        - "traefik.http.routers.images.entrypoints=websecure"
+        - "traefik.http.routers.images.tls=true"
+        - "traefik.http.services.images.loadbalancer.server.port=5000"
+        - "traefik.http.services.images.loadbalancer.passhostheader=true"
         - "traefik.docker.network=wt_traefik-net"
 
 #  celery_worker:


### PR DESCRIPTION
Adds a read-only public registry instance at `images.local.wholetale.org`. The new registry instance shares filesystem with the primary registry.

For test case see https://github.com/whole-tale/girder_wholetale/pull/551.