### PR TITLE
Fix hashbang for setup_girder.py

### DIFF
--- a/setup_girder.py
+++ b/setup_girder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 import requests
 import time


### PR DESCRIPTION
## Problem
When running `make dev`, the init script stage running `./setup_girder.py` fails with a generic error:
```
./setup_girder.py
/usr/bin/env: ‘python’: No such file or directory
make: *** [Makefile:68: dev] Error 127
```

On a default Ubuntu env, I can run `python` to access py3 but running `/usr/bin/env python` does not work without additional configuration:
```
$ python
Python 3.8.10 (default, Jun 22 2022, 20:18:18) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> exit()

$ /usr/bin/env python
/usr/bin/env: ‘python’: No such file or directory

$ /usr/bin/env python3
Python 3.8.10 (default, Jun 22 2022, 20:18:18) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> exit()

```

## Approach
Change the hashbang at the top of the file to:
```
#!/usr/bin/env python3
```

This should tell Ubuntu to use `python3` by default

If this is the wrong approach here, then feel free to disregard. I've been wondering about this one for awhile, but no one else seems to run into this

## How to Test
1. Checkout this branch locally
2. Run `make dev`
    * You should see `./setup_girder.py` starts and completes successfully