### PR TITLE
feat: Variable DOCKER_GID

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -55,7 +55,7 @@ services:
     environment:
       - DOMAIN=local.wholetale.org
       - DASHBOARD_URL=https://dashboard.local.wholetale.org
-      - GOSU_USER=girder:girder:999
+      - GOSU_USER=girder:girder:${DOCKER_GID:-999}
       - "GOSU_CHOWN=/tmp/data"
       - DATAONE_URL=https://cn-stage-2.test.dataone.org/cn
       - HOSTDIR=/

--- a/pull-upstream.sh
+++ b/pull-upstream.sh
@@ -18,7 +18,7 @@ fi
 
 # Default parameter to all subdirs
 if [ "$1" == "" ]; then
-	subdirs="dashboard,wholetale,gwvolman,wt_data_manager,wt_home_dir,globus_handler"
+	subdirs="ngx-dashboard,virtual_resources,girderfs,wholetale,gwvolman,wt_versioning,wt_data_manager,wt_home_dir,globus_handler"
 else
 	subdirs="$1"
 fi
@@ -26,5 +26,5 @@ fi
 # Loop over supplied subdirectories and pull from upstream
 for subdir in $(echo "$subdirs" | sed "s/,/ /g")
 do
-	($DEBUG cd $root_dir/src/$subdir && $DEBUG git pull origin master) || exit 1
+	($DEBUG cd $root_dir/src/$subdir && $DEBUG git status && $DEBUG git pull origin master) || exit 1
 done


### PR DESCRIPTION
## Problem
Default `DOCKER_GID` on my [Ubuntu 20.04.5 LTS (Focal Fossa)](https://releases.ubuntu.com/focal) system seems to differ from everyone else's

My value: `119`
Other environments seems to work fine with `999`

## Approach
* Roll forward `pull-upstream.sh` to include all installed plugins and repos
* `pull-upstream.sh` should also execute `git status` to see current branch for each plugin
* Allow the group for `GOSU_USER` to be set from host's environment variables (default=999)

## How to Test
1. Run `id` to see your local user's groups - find the ID for the `docker` group here
2. Set `DOCKER_GID` envvar on host: `export DOCKER_GID=119`
3. Execute `make dev` - this should start Girder with `119` as the Docker Group ID
4. (Optional) add `export DOCKER_GID=119` to your local `~/.bashrc` or `~/.profile` if your GID is not `999`